### PR TITLE
refactor event to standalone interface, refactor _isPoolRegistered to be internal

### DIFF
--- a/packages/contracts/src/PoolMetadataRegistry.sol
+++ b/packages/contracts/src/PoolMetadataRegistry.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.7.0 <0.9.0;
 
 import "@balancer-labs/v2-interfaces/contracts/vault/IVault.sol";
 
-interface PoolMetadataRegistryEvents {
+interface IPoolMetadataRegistry {
     event PoolMetadataUpdated(bytes32 indexed poolId, string metadataCID);
 }
 
@@ -11,7 +11,7 @@ interface PoolMetadataRegistryEvents {
 /// @title A Pool Metadata dApp
 /// @author Bleu LLC
 /// @notice This contract provides a registry for Balancer's Pools metadata
-contract PoolMetadataRegistry is PoolMetadataRegistryEvents {
+contract PoolMetadataRegistry is IPoolMetadataRegistry {
     IVault private immutable _vault;
 
     mapping(bytes32 => string) public poolIdMetadataCIDMap;
@@ -23,7 +23,7 @@ contract PoolMetadataRegistry is PoolMetadataRegistryEvents {
     /// @notice Checks if a Pool is registered on Balancer
     /// @param poolId The pool ID to check against the Balancer vault
     /// @return bool Returns TRUE for registered and FALSE for unregistered
-    function isPoolRegistered(bytes32 poolId) public view returns (bool) {
+    function _isPoolRegistered(bytes32 poolId) internal view returns (bool) {
         try _vault.getPool(poolId) returns (address, IVault.PoolSpecialization) {
             return true;
         } catch (bytes memory) {
@@ -35,7 +35,7 @@ contract PoolMetadataRegistry is PoolMetadataRegistryEvents {
     /// @param poolId The pool ID to update the metadata
     /// @param metadataCID The metadataCID related to the new pool metadata
     function setPoolMetadata(bytes32 poolId, string memory metadataCID) public {
-        require(isPoolRegistered(poolId), "Pool not registered");
+        require(_isPoolRegistered(poolId), "Pool not registered");
         // TODO: https://linear.app/bleu-llc/issue/BAL-85/check-if-the-caller-is-the-owner
         // require(isPoolOwner(poolId, address), "Caller is not the owner");
         poolIdMetadataCIDMap[poolId] = metadataCID;

--- a/packages/contracts/test/PoolMetadataRegistry.t.sol
+++ b/packages/contracts/test/PoolMetadataRegistry.t.sol
@@ -12,8 +12,16 @@ import "@balancer-labs/v2-pool-utils/contracts/lib/PoolRegistrationLib.sol";
 
 import {Test} from "forge-std/Test.sol";
 
-contract PoolMetadataRegistryTest is PoolMetadataRegistryEvents, Test {
-    PoolMetadataRegistry poolMetadataRegistry;
+contract MockPoolMetadataRegistry is PoolMetadataRegistry {
+    constructor(IVault vault) PoolMetadataRegistry(vault) {}
+
+    function isPoolRegistered(bytes32 poolId) public view returns (bool) {
+        return _isPoolRegistered(poolId);
+    }
+}
+
+contract PoolMetadataRegistryTest is IPoolMetadataRegistry, Test {
+    MockPoolMetadataRegistry poolMetadataRegistry;
     IVault private _vault;
 
     string private constant _testMetadataCID = "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR";
@@ -32,7 +40,7 @@ contract PoolMetadataRegistryTest is PoolMetadataRegistryEvents, Test {
         poolId =
             PoolRegistrationLib.registerComposablePool(_vault, IVault.PoolSpecialization.GENERAL, tokens, assetManagers);
 
-        poolMetadataRegistry = new PoolMetadataRegistry(_vault);
+        poolMetadataRegistry = new MockPoolMetadataRegistry(_vault);
     }
 
     function testIsPoolRegistered() public {


### PR DESCRIPTION
- refactor PoolMetadataRegistry, add test to setter
- refactor test metadata cid to contract variable
- abstract event standalone interface, refactor _isPoolRegistered to be internal
