### PR TITLE
[APR] Add retry clause when fetching tvl/volume

### DIFF
--- a/apps/balancer-tools/src/app/apr/(utils)/calculatePoolStats.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/calculatePoolStats.ts
@@ -72,9 +72,8 @@ const fetchPoolAveragesForDateRange = withCache(
       if (retyGQL.poolSnapshots.length === 0) {
         return [0, 0, "", []];
       }
-      // Gets the 2 most recent
       res.poolSnapshots = retyGQL.poolSnapshots
-        .slice(-2)
+        .slice(-1)
         .sort((a, b) => a.timestamp - b.timestamp);
     }
     const avgLiquidity =

--- a/apps/balancer-tools/src/app/apr/(utils)/calculatePoolStats.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/calculatePoolStats.ts
@@ -63,19 +63,20 @@ const fetchPoolAveragesForDateRange = withCache(
       console.warn(
         "No return on poolSnapshots, trying to fetch in a few days before",
       );
-      const retyGQL = await pools.gql(network).poolSnapshotInRange({
+      const retryGQL = await pools.gql(network).poolSnapshotInRange({
         poolId,
         from: from - SECONDS_IN_DAY * 7,
         to,
       });
 
-      if (retyGQL.poolSnapshots.length === 0) {
+      if (retryGQL.poolSnapshots.length === 0) {
         return [0, 0, "", []];
       }
-      res.poolSnapshots = retyGQL.poolSnapshots
-        .slice(-1)
-        .sort((a, b) => a.timestamp - b.timestamp);
+      res.poolSnapshots = retryGQL.poolSnapshots
+        .sort((a, b) => a.timestamp - b.timestamp)
+        .slice(-1);
     }
+
     const avgLiquidity =
       res.poolSnapshots.reduce(
         (acc, snapshot) => acc + parseFloat(snapshot.liquidity),


### PR DESCRIPTION
Fixes days without tvl, following Fabio's recommendation on [BAL-872](https://linear.app/bleu-llc/issue/BAL-872/handle-days-were-snapshot-does-not-exist#comment-be6f5eac)

[On Prod](https://tools.balancer.blue/apr/pool/ethereum/0x1a44e35d5451e0b78621a1b3e7a53dfaa306b1d000000000000000000000051b?startAt=09-14-2023&endAt=09-22-2023)
![image](https://github.com/bleu-fi/balancer-tools/assets/68453900/7fcb9c1b-9243-44bd-9e5b-d19cae4b6d21)

With the fix

![image](https://github.com/bleu-fi/balancer-tools/assets/68453900/9d709257-cf69-459e-83ed-510ddee27e28)
