### PR TITLE
[APR] Remove general avg from api

### DIFF
--- a/apps/balancer-tools/src/app/apr/(utils)/getFilteredApiUrl.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/getFilteredApiUrl.ts
@@ -47,7 +47,7 @@ function getFilterDataFromParams(searchParams: SearchParams) {
   return result;
 }
 
-export default function getFilteredRoundApiUrl(
+export default function getFilteredDateApiUrl(
   startAt: Date,
   endAt: Date,
   searchParams?: SearchParams | null,

--- a/apps/balancer-tools/src/app/apr/api/(utils)/computeAverages.ts
+++ b/apps/balancer-tools/src/app/apr/api/(utils)/computeAverages.ts
@@ -1,9 +1,5 @@
 import { calculatePoolData } from "../../(utils)/calculatePoolStats";
-import {
-  PoolStatsData,
-  PoolStatsResults,
-  PoolStatsWithoutVotingShareAndCollectedFees,
-} from "../route";
+import { PoolStatsData, PoolStatsResults } from "../route";
 
 export const computeAverages = (formattedPoolData: {
   [key: string]: PoolStatsData[] | calculatePoolData[];
@@ -108,7 +104,7 @@ function initializeAverages(): { poolAverage: PoolStatsData[] } {
 }
 
 function accumulateData(
-  obj1: PoolStatsWithoutVotingShareAndCollectedFees,
+  obj1: PoolStatsData[],
   obj2: PoolStatsData | calculatePoolData,
 ) {
   const result = { ...obj1 };

--- a/apps/balancer-tools/src/app/apr/api/(utils)/computeAverages.ts
+++ b/apps/balancer-tools/src/app/apr/api/(utils)/computeAverages.ts
@@ -1,9 +1,9 @@
 import { calculatePoolData } from "../../(utils)/calculatePoolStats";
-import { PoolStatsData, PoolStatsResults } from "../route";
+import { PoolStatsData } from "../route";
 
 export const computeAverages = (formattedPoolData: {
   [key: string]: PoolStatsData[] | calculatePoolData[];
-}): PoolStatsResults => {
+}): { poolAverage: PoolStatsData[] } => {
   const averages = initializeAverages();
 
   const poolAverage: { [key: string]: PoolStatsData | calculatePoolData } = {};

--- a/apps/balancer-tools/src/app/apr/api/route.ts
+++ b/apps/balancer-tools/src/app/apr/api/route.ts
@@ -120,15 +120,14 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  const filteredRespondeData = limitPoolStats(filterPoolStats(responseData, searchParams), offset, limit)
+
   return NextResponse.json(
     sortPoolStats(
-      computeAverages(
-        limitPoolStats(
-          filterPoolStats(responseData, searchParams),
-          offset,
-          limit,
-        ),
-      ),
+      {
+        perDay:  filteredRespondeData,
+        average: computeAverages(filteredRespondeData)
+      },
       sort as keyof PoolStatsData | undefined,
       order as Order | undefined,
     ),

--- a/apps/balancer-tools/src/app/apr/api/route.ts
+++ b/apps/balancer-tools/src/app/apr/api/route.ts
@@ -46,11 +46,6 @@ export interface PoolStats {
   collectedFeesUSD: number;
 }
 
-export interface PoolStatsWithoutVotingShareAndCollectedFees
-  extends Omit<PoolStats, "votingShare" | "collectedFeesUSD"> {
-  poolAverage: PoolStatsData[];
-}
-
 export interface PoolStatsData extends PoolStats {
   symbol: string;
   network: string;
@@ -61,7 +56,7 @@ export interface PoolStatsData extends PoolStats {
 
 export interface PoolStatsResults {
   perDay: { [key: string]: PoolStatsData[] };
-  average: PoolStatsWithoutVotingShareAndCollectedFees;
+  average: { poolAverage: PoolStatsData[] };
 }
 
 function valuesFromSearchParams(searchParams: URLSearchParams) {

--- a/apps/balancer-tools/src/app/apr/api/route.ts
+++ b/apps/balancer-tools/src/app/apr/api/route.ts
@@ -120,13 +120,17 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const filteredRespondeData = limitPoolStats(filterPoolStats(responseData, searchParams), offset, limit)
+  const filteredRespondeData = limitPoolStats(
+    filterPoolStats(responseData, searchParams),
+    offset,
+    limit,
+  );
 
   return NextResponse.json(
     sortPoolStats(
       {
-        perDay:  filteredRespondeData,
-        average: computeAverages(filteredRespondeData)
+        perDay: filteredRespondeData,
+        average: computeAverages(filteredRespondeData),
       },
       sort as keyof PoolStatsData | undefined,
       order as Order | undefined,

--- a/apps/balancer-tools/src/app/apr/page.tsx
+++ b/apps/balancer-tools/src/app/apr/page.tsx
@@ -22,12 +22,7 @@ export interface SearchParams {
   network?: string;
 }
 
-export default function Page({
-  searchParams,
-}: {
-  params: { roundId: string };
-  searchParams: SearchParams;
-}) {
+export default function Page({ searchParams }: { searchParams: SearchParams }) {
   const parsedParams = QueryParamsPagesSchema.safeParse(searchParams);
   if (!parsedParams.success) {
     const currentDateFormated = formatDateToMMDDYYYY(new Date());

--- a/apps/balancer-tools/src/app/apr/page.tsx
+++ b/apps/balancer-tools/src/app/apr/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import ChartSkelton from "./(components)/(skeleton)/ChartSkelton";
 import KpisSkeleton from "./(components)/(skeleton)/KpisSkeleton";
 import TableSkeleton from "./(components)/(skeleton)/TableSkeleton";
-import getFilteredRoundApiUrl from "./(utils)/getFilteredApiUrl";
+import getFilteredDateApiUrl from "./(utils)/getFilteredApiUrl";
 import { formatDateToMMDDYYYY } from "./api/(utils)/date";
 import { QueryParamsPagesSchema } from "./api/(utils)/validate";
 import Breadcrumb from "./round/(components)/Breadcrumb";
@@ -43,7 +43,7 @@ export default function Page({
     return redirect("/apr/");
   }
 
-  const url = getFilteredRoundApiUrl(startAtDate, endAtDate, searchParams);
+  const url = getFilteredDateApiUrl(startAtDate, endAtDate, searchParams);
 
   return (
     <div className="flex flex-1 flex-col gap-y-3">

--- a/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalCharts/index.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalCharts/index.tsx
@@ -1,4 +1,4 @@
-import getFilteredRoundApiUrl from "#/app/apr/(utils)/getFilteredApiUrl";
+import getFilteredDateApiUrl from "#/app/apr/(utils)/getFilteredApiUrl";
 import { PoolStatsData, PoolStatsResults } from "#/app/apr/api/route";
 import { trimTrailingValues } from "#/lib/utils";
 import { fetcher } from "#/utils/fetcher";
@@ -15,7 +15,7 @@ export default async function HistoricalCharts({
   poolId?: string;
 }) {
   const results: PoolStatsResults = await fetcher(
-    getFilteredRoundApiUrl(startAt, endAt, null, poolId),
+    getFilteredDateApiUrl(startAt, endAt, null, poolId),
   );
 
   return <HistoricalChart apiResult={results} />;

--- a/apps/balancer-tools/src/app/apr/pool/(components)/PoolOverviewCards.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/PoolOverviewCards.tsx
@@ -26,10 +26,13 @@ export default async function PoolOverviewCards({
   );
   cardsDetails.push(
     ...[
-      { title: "Avg. TVL", content: formatTVL(results.average.tvl) },
+      {
+        title: "Avg. TVL",
+        content: formatTVL(results.average.poolAverage[0].tvl),
+      },
       {
         title: "Avg. veBAL APR",
-        content: formatAPR(results.average.apr.breakdown.veBAL),
+        content: formatAPR(results.average.poolAverage[0].apr.breakdown.veBAL),
       },
       ...getDatesDetails(startAt, endAt),
     ],

--- a/apps/balancer-tools/src/app/apr/pool/(components)/PoolOverviewCards.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/PoolOverviewCards.tsx
@@ -4,7 +4,7 @@ import OverviewCards, {
   getDatesDetails,
 } from "../../(components)/OverviewCards";
 import { formatAPR, formatTVL } from "../../(utils)/formatPoolStats";
-import getFilteredRoundApiUrl from "../../(utils)/getFilteredApiUrl";
+import getFilteredDateApiUrl from "../../(utils)/getFilteredApiUrl";
 import { PoolStatsResults } from "../../api/route";
 
 export default async function PoolOverviewCards({
@@ -22,7 +22,7 @@ export default async function PoolOverviewCards({
     tooltip?: string;
   }[] = [];
   const results: PoolStatsResults = await fetcher(
-    getFilteredRoundApiUrl(startAt, endAt, null, poolId),
+    getFilteredDateApiUrl(startAt, endAt, null, poolId),
   );
   cardsDetails.push(
     ...[

--- a/apps/balancer-tools/src/app/apr/round/(components)/PoolListTable.tsx
+++ b/apps/balancer-tools/src/app/apr/round/(components)/PoolListTable.tsx
@@ -27,7 +27,7 @@ import { fetcher } from "#/utils/fetcher";
 import { formatNumber } from "#/utils/formatNumber";
 
 import { formatAPR, formatTVL } from "../../(utils)/formatPoolStats";
-import getFilteredRoundApiUrl from "../../(utils)/getFilteredApiUrl";
+import getFilteredDateApiUrl from "../../(utils)/getFilteredApiUrl";
 import { PoolTypeEnum } from "../../(utils)/types";
 import { formatDateToMMDDYYYY } from "../../api/(utils)/date";
 import { PoolStatsData, PoolStatsResults, PoolTokens } from "../../api/route";
@@ -75,7 +75,7 @@ export function PoolListTable({
     const params = Object.fromEntries(searchParams.entries());
     params["offset"] = (tableData.length + 1).toString();
 
-    const url = new URL(getFilteredRoundApiUrl(startAt, endAt, params));
+    const url = new URL(getFilteredDateApiUrl(startAt, endAt, params));
     const aditionalPoolsData = await fetcher<PoolStatsResults>(
       url.pathname + url.search,
     );


### PR DESCRIPTION
This is working for one pool, but not for home date range

http://localhost:3000/apr/pool/ethereum/0x1e19cf2d73a72ef1332c882f20534b6519be0276000200000000000000000112?startAt=09-18-2023&endAt=09-21-2023