### PR TITLE
[APR] Add additional arg to SearchPoolForm to filter GQL

### DIFF
--- a/apps/balancer-tools/src/app/apr/(components)/HeaderEndButton.tsx
+++ b/apps/balancer-tools/src/app/apr/(components)/HeaderEndButton.tsx
@@ -59,7 +59,7 @@ export default function HeaderEndButton() {
             defaultValueNetwork={networkIdFor(network as string)}
             onSubmit={handlePoolClick}
             showPools
-            onlyVotingGauges
+            gqlAdditionalVariable={{ totalLiquidity_gt: 5000 }}
           />
         }
       >

--- a/apps/balancer-tools/src/app/poolsimulator/(components)/SearchPoolFormDialog.tsx
+++ b/apps/balancer-tools/src/app/poolsimulator/(components)/SearchPoolFormDialog.tsx
@@ -26,7 +26,7 @@ export function SearchPoolFormDialog({
       title="Import pool parameters"
       content={
         <SearchPoolForm
-          poolTypeFilter={poolTypes[poolTypeFilter]}
+          gqlAdditionalVariable={{ poolTypes: poolTypes[poolTypeFilter] }}
           onSubmit={onSubmit}
           showPools
         />

--- a/apps/balancer-tools/src/components/SearchPoolForm/index.tsx
+++ b/apps/balancer-tools/src/components/SearchPoolForm/index.tsx
@@ -27,7 +27,6 @@ const inputTypenames = [
 
 export function SearchPoolForm({
   close,
-  poolTypeFilter,
   onSubmit,
   showPools = false,
   onlyVotingGauges = false,
@@ -36,10 +35,10 @@ export function SearchPoolForm({
   form = useForm<PoolAttribute>(),
   availableNetworks = inputTypenames,
   children,
+  gqlAdditionalVariable,
 }: {
   onSubmit?: (formData: PoolAttribute) => void;
   close?: () => void;
-  poolTypeFilter?: string[];
   showPools?: boolean;
   onlyVotingGauges?: boolean;
   defaultValueNetwork?: string;
@@ -47,6 +46,7 @@ export function SearchPoolForm({
   form?: UseFormReturn<PoolAttribute>;
   availableNetworks?: { value: string; label: string }[];
   children?: ReactNode | undefined;
+  gqlAdditionalVariable?: { [key: string]: string[] | string | number };
 }) {
   const [comboBoxIsOpen, setComboBoxIsOpen] = useState(false);
   const {
@@ -63,7 +63,7 @@ export function SearchPoolForm({
 
   const gqlVariables = {
     poolId: poolId?.toLowerCase(),
-    ...(poolTypeFilter?.length ? { poolTypes: poolTypeFilter } : {}),
+    ...gqlAdditionalVariable,
   };
 
   const { data: poolsData } = pools
@@ -73,7 +73,8 @@ export function SearchPoolForm({
   const { data: poolsDataList, mutate: poolsDataListMutate } = pools
     .gql(network || "1")
     .usePoolsWherePoolType(
-      poolTypeFilter?.length ? { poolTypes: poolTypeFilter } : {},
+      gqlAdditionalVariable,
+      // poolTypeFilter?.length ? { poolTypes: poolTypeFilter } : {},
       { revalidateIfStale: true },
     );
 
@@ -191,8 +192,10 @@ export function SearchPoolForm({
                         <span>
                           {/* By default, FX pools have the name equal to "BPT".
                             So, we'll use name instead of the symbol, since it is more meaningful */}
-                          {poolTypeFilter?.[0] == "FX" &&
-                          poolTypeFilter?.length == 1
+                          {gqlAdditionalVariable?.poolTypeFilter &&
+                          Array.isArray(gqlAdditionalVariable.poolTypeFilter) &&
+                          gqlAdditionalVariable.poolTypeFilter?.[0] == "FX" &&
+                          gqlAdditionalVariable.poolTypeFilter?.length == 1
                             ? pool.name
                             : pool.symbol}
                         </span>

--- a/apps/balancer-tools/src/components/SearchPoolForm/index.tsx
+++ b/apps/balancer-tools/src/components/SearchPoolForm/index.tsx
@@ -72,11 +72,7 @@ export function SearchPoolForm({
 
   const { data: poolsDataList, mutate: poolsDataListMutate } = pools
     .gql(network || "1")
-    .usePoolsWherePoolType(
-      gqlAdditionalVariable,
-      // poolTypeFilter?.length ? { poolTypes: poolTypeFilter } : {},
-      { revalidateIfStale: true },
-    );
+    .usePoolsWherePoolType(gqlAdditionalVariable, { revalidateIfStale: true });
 
   function handleSubmitForm(formData: PoolAttribute) {
     onSubmit?.(formData);
@@ -192,10 +188,10 @@ export function SearchPoolForm({
                         <span>
                           {/* By default, FX pools have the name equal to "BPT".
                             So, we'll use name instead of the symbol, since it is more meaningful */}
-                          {gqlAdditionalVariable?.poolTypeFilter &&
-                          Array.isArray(gqlAdditionalVariable.poolTypeFilter) &&
-                          gqlAdditionalVariable.poolTypeFilter?.[0] == "FX" &&
-                          gqlAdditionalVariable.poolTypeFilter?.length == 1
+                          {gqlAdditionalVariable?.poolTypes &&
+                          Array.isArray(gqlAdditionalVariable.poolTypes) &&
+                          gqlAdditionalVariable.poolTypes?.[0] == "FX" &&
+                          gqlAdditionalVariable.poolTypes?.length == 1
                             ? pool.name
                             : pool.symbol}
                         </span>


### PR DESCRIPTION
Preview link: https://tools-monorepo-2i09av0rl-bleu-fi.vercel.app/
Preview link for pool simulator: https://tools-monorepo-2i09av0rl-bleu-fi.vercel.app/poolsimulator

This PR:
- adds gqlAdditionalVariable to SearchPoolForm
- Refactor Pool simulator SearchPoolForm to get pools by type using gqlAdditionalVariable
- on APR gets only pools that have the TVL greater then 5k