### PR TITLE
[APR] Robust token yield apr

### DIFF
--- a/apps/balancer-tools/src/app/apr/(utils)/getBlockNumberByTimestamp.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/getBlockNumberByTimestamp.ts
@@ -37,11 +37,9 @@ async function bestGuess(chain: number, timestamp: number): Promise<number> {
 export default async function getBlockNumberByTimestamp(
   chain: number,
   endTime: number,
-): Promise<number> {
+): Promise<number | undefined> {
   if (endTime > dateToEpoch(new Date())) {
-    throw new Error(
-      `The specified endTime cannot be in the future. EndTime: ${endTime}`,
-    );
+    return undefined;
   }
 
   if (chain === NetworkChainId.GNOSIS) {

--- a/apps/balancer-tools/src/app/apr/(utils)/tokenYield.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/tokenYield.ts
@@ -38,16 +38,28 @@ export async function getPoolTokensAprForDateRange(
         async ({
           address: rateProviderAddress,
           token: { symbol, address: tokenAddress },
-        }) => ({
-          address: tokenAddress,
-          symbol,
-          yield: await getAPRFromRateProviderInterval(
-            rateProviderAddress as Address,
-            startAt,
-            endAt,
-            chainName,
-          ),
-        }),
+        }) => {
+          try {
+            return {
+              address: tokenAddress,
+              symbol,
+              yield: await getAPRFromRateProviderInterval(
+                rateProviderAddress as Address,
+                startAt,
+                endAt,
+                chainName,
+              ),
+            };
+          } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error(`Error fetching yield for ${symbol}: ${error}`);
+            return {
+              address: tokenAddress,
+              symbol,
+              yield: 0,
+            };
+          }
+        },
       ),
   );
 }
@@ -91,8 +103,8 @@ async function getAPRFromRateProviderInterval(
     console.error(
       `Error fetching rate for ${rateProviderAddress} between ${timeStart} and ${timeEnd} chain ${chainName} - ${e}`,
     );
-    Sentry.captureException(e)
-    throw e
+    Sentry.captureException(e);
+    throw e;
   }
 }
 
@@ -184,8 +196,8 @@ const getRateAtBlock = withCache(async function getRateAtBlockFn(
     console.error(
       `Error fetching rate for ${rateProviderAddress} at block ${blockNumber} on ${chainName}, ${e}`,
     );
-    Sentry.captureException(e)
-    throw e
+    Sentry.captureException(e);
+    throw e;
   }
 
   return Number(rate);

--- a/apps/balancer-tools/src/app/apr/(utils)/tokenYield.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/tokenYield.ts
@@ -1,4 +1,5 @@
 import { Address, networkFor, networkIdFor } from "@bleu-balancer-tools/utils";
+import * as Sentry from "@sentry/nextjs";
 import { zeroAddress } from "viem";
 
 import { withCache } from "#/lib/cache";
@@ -90,7 +91,8 @@ async function getAPRFromRateProviderInterval(
     console.error(
       `Error fetching rate for ${rateProviderAddress} between ${timeStart} and ${timeEnd} chain ${chainName} - ${e}`,
     );
-    return 0;
+    Sentry.captureException(e)
+    throw e
   }
 }
 
@@ -182,7 +184,8 @@ const getRateAtBlock = withCache(async function getRateAtBlockFn(
     console.error(
       `Error fetching rate for ${rateProviderAddress} at block ${blockNumber} on ${chainName}, ${e}`,
     );
-    rate = -1;
+    Sentry.captureException(e)
+    throw e
   }
 
   return Number(rate);

--- a/apps/balancer-tools/src/app/apr/(utils)/tokenYield.ts
+++ b/apps/balancer-tools/src/app/apr/(utils)/tokenYield.ts
@@ -52,7 +52,9 @@ export async function getPoolTokensAprForDateRange(
             };
           } catch (error) {
             // eslint-disable-next-line no-console
-            console.error(`Error fetching yield for ${symbol}: ${error}`);
+            console.error(
+              `Error fetching yield for Pool ${poolId} - ${symbol}: ${error}`,
+            );
             return {
               address: tokenAddress,
               symbol,

--- a/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalCharts/FilterTabs.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalCharts/FilterTabs.tsx
@@ -32,6 +32,7 @@ export default function FilterTabs({
           className="cursor-pointer flex grow justify-center items-center sm:min-w-[96px] min-w-[76px] sm:h-9 h-7 rounded-full"
           role="radio"
           aria-checked={selectedTabs.includes(idx)}
+          key={idx}
           tabIndex={idx}
           id={String(idx)}
           data-headlessui-state="checked"


### PR DESCRIPTION
On prod some pools are returning "0" on token yield where it shouldn't be [[example](https://balancer-tools.bleu.fi/apr/pool/ethereum/0x1ee442b5326009bb18f2f472d3e0061513d1a0ff000200000000000000000464?startAt=09-30-2023&endAt=10-03-2023)]. I couldn't replicate on dev., so I went for trying to make it more robust, and warn us whenever an error occurs.