### PR TITLE
[APR] Fix for not averaging nested objects

### DIFF
--- a/apps/balancer-tools/src/app/apr/api/(utils)/computeAverages.ts
+++ b/apps/balancer-tools/src/app/apr/api/(utils)/computeAverages.ts
@@ -61,6 +61,9 @@ function calculateAverageForObject(
             ? Number(item) / divisor
             : item,
         );
+      } else if (typeof value === "object") {
+        // @ts-ignore  - Need help with this typing!
+        result[key] = calculateAverageForObject(value, divisor);
       } else if (typeof value === "number") {
         // @ts-ignore  - Need help with this typing!
         result[key] = value / divisor;

--- a/apps/balancer-tools/src/data/pools-without-gauge.json
+++ b/apps/balancer-tools/src/data/pools-without-gauge.json
@@ -1,0 +1,10664 @@
+[
+  {
+    "chain": "MAINNET",
+    "id": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014",
+    "address": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56",
+    "symbol": "B-80BAL-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1620153071,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba100000625a3754423978a60c9317c58a424e3d.png",
+        "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+        "symbol": "BAL",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x1e19cf2d73a72ef1332c882f20534b6519be0276000200000000000000000112",
+    "address": "0x1e19cf2d73a72ef1332c882f20534b6519be0276",
+    "symbol": "B-rETH-STABLE",
+    "type": "METASTABLE",
+    "addedTimestamp": 1640057323,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png",
+        "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+        "symbol": "rETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x93d199263632a4ef4bb438f1feb99e57b4b5f0bd0000000000000000000005c2",
+    "address": "0x93d199263632a4ef4bb438f1feb99e57b4b5f0bd",
+    "symbol": "wstETH-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692039167,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "address": "0x93d199263632a4ef4bb438f1feb99e57b4b5f0bd",
+        "symbol": "wstETH-WETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x42ed016f826165c2e5976fe5bc3df540c5ad0af700000000000000000000058b",
+    "address": "0x42ed016f826165c2e5976fe5bc3df540c5ad0af7",
+    "symbol": "wstETH-rETH-sfrxETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689162815,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x42ed016f826165c2e5976fe5bc3df540c5ad0af7",
+        "symbol": "wstETH-rETH-sfrxETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xac3e018457b222d93114458476f3e3416abbe38f.png",
+        "address": "0xac3e018457b222d93114458476f3e3416abbe38f",
+        "symbol": "sfrxETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png",
+        "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+        "symbol": "rETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x1ee442b5326009bb18f2f472d3e0061513d1a0ff000200000000000000000464",
+    "address": "0x1ee442b5326009bb18f2f472d3e0061513d1a0ff",
+    "symbol": "50rETH-50BADGER",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1675901651,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/13287/large/badger_dao_logo.jpg?1607054976",
+        "address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
+        "symbol": "BADGER",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png",
+        "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+        "symbol": "rETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x76fcf0e8c7ff37a47a799fa2cd4c13cde0d981c90002000000000000000003d2",
+    "address": "0x76fcf0e8c7ff37a47a799fa2cd4c13cde0d981c9",
+    "symbol": "50OHM-50DAI",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1668711983,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png",
+        "address": "0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5",
+        "symbol": "OHM",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x8353157092ed8be69a9df8f95af097bbf33cb2af0000000000000000000005d9",
+    "address": "0x8353157092ed8be69a9df8f95af097bbf33cb2af",
+    "symbol": "GHO/USDT/USDC",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692910907,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/30663/large/ghoaave.jpeg?1686151372",
+        "address": "0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f",
+        "symbol": "GHO",
+        "weight": null
+      },
+      {
+        "address": "0x8353157092ed8be69a9df8f95af097bbf33cb2af",
+        "symbol": "GHO/USDT/USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        "symbol": "USDT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x3ff3a210e57cfe679d9ad1e9ba6453a716c56a2e0002000000000000000005d5",
+    "address": "0x3ff3a210e57cfe679d9ad1e9ba6453a716c56a2e",
+    "symbol": "STG/USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1692722363,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6.png",
+        "address": "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",
+        "symbol": "STG",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x3dd0843a028c86e0b760b1a76929d1c5ef93a2dd000200000000000000000249",
+    "address": "0x3dd0843a028c86e0b760b1a76929d1c5ef93a2dd",
+    "symbol": "B-auraBAL-STABLE",
+    "type": "STABLE",
+    "addedTimestamp": 1655199962,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5c6ee304399dbdb9c8ef030ab642b10820db8f56.png",
+        "address": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56",
+        "symbol": "B-80BAL-20WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x616e8bfa43f920657b3497dbf40d6b1a02d4608d.png",
+        "address": "0x616e8bfa43f920657b3497dbf40d6b1a02d4608d",
+        "symbol": "auraBAL",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xf4c0dd9b82da36c07605df83c8a416f11724d88b000200000000000000000026",
+    "address": "0xf4c0dd9b82da36c07605df83c8a416f11724d88b",
+    "symbol": "B-80GNO-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1620161592,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png",
+        "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+        "symbol": "GNO",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x37b18b10ce5635a84834b26095a0ae5639dcb7520000000000000000000005cb",
+    "address": "0x37b18b10ce5635a84834b26095a0ae5639dcb752",
+    "symbol": "ETHx-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692370715,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x37b18b10ce5635a84834b26095a0ae5639dcb752",
+        "symbol": "ETHx-WETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/30870/large/ETHx-small.png?1688373266",
+        "address": "0xa35b1b31ce002fbf2058d22f30f95d405200a15b",
+        "symbol": "ETHx",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xff4ce5aaab5a627bf82f4a571ab1ce94aa365ea6000200000000000000000426",
+    "address": "0xff4ce5aaab5a627bf82f4a571ab1ce94aa365ea6",
+    "symbol": "DOLA-USDC BSP",
+    "type": "STABLE",
+    "addedTimestamp": 1673286311,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x865377367054516e17014ccded1e7d814edc9ce4.png",
+        "address": "0x865377367054516e17014ccded1e7d814edc9ce4",
+        "symbol": "DOLA",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080",
+    "address": "0x32296969ef14eb0c6d29669c550d4a0449130230",
+    "symbol": "B-stETH-STABLE",
+    "type": "METASTABLE",
+    "addedTimestamp": 1628875520,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xdfe6e7e18f6cc65fa13c8d8966013d4fda74b6ba000000000000000000000558",
+    "address": "0xdfe6e7e18f6cc65fa13c8d8966013d4fda74b6ba",
+    "symbol": "ankrETH/wstETH",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1685154395,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "address": "0xdfe6e7e18f6cc65fa13c8d8966013d4fda74b6ba",
+        "symbol": "ankrETH/wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe95a203b1a91a908f9b9ce46459d101078c2c3cb.png",
+        "address": "0xe95a203b1a91a908f9b9ce46459d101078c2c3cb",
+        "symbol": "ankrETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x20a61b948e33879ce7f23e535cc7baa3bc66c5a9000000000000000000000555",
+    "address": "0x20a61b948e33879ce7f23e535cc7baa3bc66c5a9",
+    "symbol": "R-DAI-BLP",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1684857023,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x183015a9ba6ff60230fdeadc3f43b3d788b13e21.png",
+        "address": "0x183015a9ba6ff60230fdeadc3f43b3d788b13e21",
+        "symbol": "R",
+        "weight": null
+      },
+      {
+        "address": "0x20a61b948e33879ce7f23e535cc7baa3bc66c5a9",
+        "symbol": "R-DAI-BLP",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xcb0e14e96f2cefa8550ad8e4aea344f211e5061d00020000000000000000011a",
+    "address": "0xcb0e14e96f2cefa8550ad8e4aea344f211e5061d",
+    "symbol": "20WETH-80PSP",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1640775783,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xcafe001067cdef266afb7eb5a286dcfd277f3de5",
+        "symbol": "PSP",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xe7e2c68d3b13d905bbb636709cf4dfd21076b9d20000000000000000000005ca",
+    "address": "0xe7e2c68d3b13d905bbb636709cf4dfd21076b9d2",
+    "symbol": "swETH-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692370463,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "address": "0xe7e2c68d3b13d905bbb636709cf4dfd21076b9d2",
+        "symbol": "swETH-WETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf951e335afb289353dc249e82926178eac7ded78.png",
+        "address": "0xf951e335afb289353dc249e82926178eac7ded78",
+        "symbol": "swETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xb460daa847c45f1c4a41cb05bfb3b51c92e41b36000200000000000000000194",
+    "address": "0xb460daa847c45f1c4a41cb05bfb3b51c92e41b36",
+    "symbol": "20WBTC-80BADGER",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1649360431,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "symbol": "WBTC",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/13287/large/badger_dao_logo.jpg?1607054976",
+        "address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
+        "symbol": "BADGER",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x8bd4a1e74a27182d23b98c10fd21d4fbb0ed4ba00002000000000000000004ed",
+    "address": "0x8bd4a1e74a27182d23b98c10fd21d4fbb0ed4ba0",
+    "symbol": "50TEMPLE-50DAI",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1680238631,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x470ebf5f030ed85fc1ed4c2d36b9dd02e77cf1b7.png",
+        "address": "0x470ebf5f030ed85fc1ed4c2d36b9dd02e77cf1b7",
+        "symbol": "TEMPLE",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xf16aee6a71af1a9bc8f56975a4c2705ca7a782bc0002000000000000000004bb",
+    "address": "0xf16aee6a71af1a9bc8f56975a4c2705ca7a782bc",
+    "symbol": "20WETH-80ALCX",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1677780875,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xdbdb4d16eda451d0503b854cf79d55697f90c8df.png",
+        "address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+        "symbol": "ALCX",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x9232a548dd9e81bac65500b5e0d918f8ba93675c000200000000000000000423",
+    "address": "0x9232a548dd9e81bac65500b5e0d918f8ba93675c",
+    "symbol": "BAL-20WETH-80LIT",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1672973951,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfd0205066521550d7d7ab19da8f72bb004b4c341.png",
+        "address": "0xfd0205066521550d7d7ab19da8f72bb004b4c341",
+        "symbol": "LIT",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xcfca23ca9ca720b6e98e3eb9b6aa0ffc4a5c08b9000200000000000000000274",
+    "address": "0xcfca23ca9ca720b6e98e3eb9b6aa0ffc4a5c08b9",
+    "symbol": "50WETH-50AURA",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1656324819,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc0c293ce456ff0ed870add98a0828dd4d2903dbf.png",
+        "address": "0xc0c293ce456ff0ed870add98a0828dd4d2903dbf",
+        "symbol": "AURA",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x5aee1e99fe86960377de9f88689616916d5dcabe000000000000000000000467",
+    "address": "0x5aee1e99fe86960377de9f88689616916d5dcabe",
+    "symbol": "wstETH-rETH-sfrxETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1675903979,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x5aee1e99fe86960377de9f88689616916d5dcabe",
+        "symbol": "wstETH-rETH-sfrxETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xac3e018457b222d93114458476f3e3416abbe38f.png",
+        "address": "0xac3e018457b222d93114458476f3e3416abbe38f",
+        "symbol": "sfrxETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png",
+        "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+        "symbol": "rETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xb08885e6026bab4333a80024ec25a1a3e1ff2b8a000200000000000000000445",
+    "address": "0xb08885e6026bab4333a80024ec25a1a3e1ff2b8a",
+    "symbol": "B-staFiETH-WETH-Stable",
+    "type": "METASTABLE",
+    "addedTimestamp": 1675048919,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x9559aaa82d9649c7a7b220e7c461d2e74c9a3593.png",
+        "address": "0x9559aaa82d9649c7a7b220e7c461d2e74c9a3593",
+        "symbol": "rETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x9f9d900462492d4c21e9523ca95a7cd86142f298000200000000000000000462",
+    "address": "0x9f9d900462492d4c21e9523ca95a7cd86142f298",
+    "symbol": "50rETH-50RPL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1675890263,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png",
+        "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+        "symbol": "rETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd33526068d116ce69f19a9ee46f0bd304f21a51f.png",
+        "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+        "symbol": "RPL",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xc29562b045d80fd77c69bec09541f5c16fe20d9d000200000000000000000251",
+    "address": "0xc29562b045d80fd77c69bec09541f5c16fe20d9d",
+    "symbol": "B-80AURA-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1655300061,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc0c293ce456ff0ed870add98a0828dd4d2903dbf.png",
+        "address": "0xc0c293ce456ff0ed870add98a0828dd4d2903dbf",
+        "symbol": "AURA",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x92762b42a06dcdddc5b7362cfb01e631c4d44b40000200000000000000000182",
+    "address": "0x92762b42a06dcdddc5b7362cfb01e631c4d44b40",
+    "symbol": "50COW-50GNO",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1648477203,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png",
+        "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+        "symbol": "GNO",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab.png",
+        "address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+        "symbol": "COW",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e",
+    "address": "0xa6f548df93de924d73be7d25dc02554c6bd66db5",
+    "symbol": "B-50WBTC-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1620134851,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "symbol": "WBTC",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x5122e01d819e58bb2e22528c0d68d310f0aa6fd7000200000000000000000163",
+    "address": "0x5122e01d819e58bb2e22528c0d68d310f0aa6fd7",
+    "symbol": "sNOTE-BPT",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1647289895,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xcfeaead4947f0705a14ec42ac3d44129e1ef3ed5.png",
+        "address": "0xcfeaead4947f0705a14ec42ac3d44129e1ef3ed5",
+        "symbol": "NOTE",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xf01b0684c98cd7ada480bfdf6e43876422fa1fc10002000000000000000005de",
+    "address": "0xf01b0684c98cd7ada480bfdf6e43876422fa1fc1",
+    "symbol": "ECLP-wstETH-wETH",
+    "type": "GYROE",
+    "addedTimestamp": 1693249103,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xa3c500969accb3d8df08cba313c120818fe0ed9d000200000000000000000471",
+    "address": "0xa3c500969accb3d8df08cba313c120818fe0ed9d",
+    "symbol": "50SYN-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1675956923,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0f2d719407fdbeff09d87557abb7232601fd9f29.png",
+        "address": "0x0f2d719407fdbeff09d87557abb7232601fd9f29",
+        "symbol": "SYN",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x350196326aeaa9b98f1903fb5e8fc2686f85318c000200000000000000000084",
+    "address": "0x350196326aeaa9b98f1903fb5e8fc2686f85318c",
+    "symbol": "VBPT",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1629982123,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321.png",
+        "address": "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+        "symbol": "VITA",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x9cc64ee4cb672bc04c54b00a37e1ed75b2cc19dd0002000000000000000004c1",
+    "address": "0x9cc64ee4cb672bc04c54b00a37e1ed75b2cc19dd",
+    "symbol": "80Silo-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1678213451,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6f80310ca7f2c654691d1383149fa1a57d8ab1f8.png",
+        "address": "0x6f80310ca7f2c654691d1383149fa1a57d8ab1f8",
+        "symbol": "Silo",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x68e3266c9c8bbd44ad9dca5afbfe629022aee9fe000200000000000000000512",
+    "address": "0x68e3266c9c8bbd44ad9dca5afbfe629022aee9fe",
+    "symbol": "B-wjAura-wETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1681226003,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x198d7387fa97a73f05b8578cdeff8f2a1f34cd1f.png",
+        "address": "0x198d7387fa97a73f05b8578cdeff8f2a1f34cd1f",
+        "symbol": "wjAURA",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x8eb6c82c3081bbbd45dcac5afa631aac53478b7c000100000000000000000270",
+    "address": "0x8eb6c82c3081bbbd45dcac5afa631aac53478b7c",
+    "symbol": "40WBTC-40DIGG-20graviAURA",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1656113097,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "symbol": "WBTC",
+        "weight": "0.4"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/13737/large/digg.PNG?1611292196",
+        "address": "0x798d1be841a82a273720ce31c822c61a67a601c3",
+        "symbol": "DIGG",
+        "weight": "0.4"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba485b556399123261a5f9c95d413b4f93107407.png",
+        "address": "0xba485b556399123261a5f9c95d413b4f93107407",
+        "symbol": "graviAURA",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xbc5f4f9332d8415aaf31180ab4661c9141cc84e4000200000000000000000262",
+    "address": "0xbc5f4f9332d8415aaf31180ab4661c9141cc84e4",
+    "symbol": "98TXJP-2WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1655613614,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x961dd84059505d59f82ce4fb87d3c09bec65301d",
+        "symbol": "TXJP",
+        "weight": "0.98"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.02"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xf7a826d47c8e02835d94fb0aa40f0cc9505cb1340002000000000000000005e0",
+    "address": "0xf7a826d47c8e02835d94fb0aa40f0cc9505cb134",
+    "symbol": "ECLP-wstETH-cbETH",
+    "type": "GYROE",
+    "addedTimestamp": 1693336211,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbe9895146f7af43049ca1c1ae358b0541ea49704.png",
+        "address": "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
+        "symbol": "cbETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xd1ec5e215e8148d76f4460e4097fd3d5ae0a35580002000000000000000003d3",
+    "address": "0xd1ec5e215e8148d76f4460e4097fd3d5ae0a3558",
+    "symbol": "50OHM-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1668711983,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png",
+        "address": "0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5",
+        "symbol": "OHM",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x3fa8c89704e5d07565444009e5d9e624b40be813000000000000000000000599",
+    "address": "0x3fa8c89704e5d07565444009e5d9e624b40be813",
+    "symbol": "GHO/LUSD",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689432875,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x3fa8c89704e5d07565444009e5d9e624b40be813",
+        "symbol": "GHO/LUSD",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/30663/large/ghoaave.jpeg?1686151372",
+        "address": "0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f",
+        "symbol": "GHO",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5f98805a4e8be255a32880fdec7f6728c6568ba0.png",
+        "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+        "symbol": "LUSD",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x514f35a92a13bc7093f299af5d8ebb1387e42d6b0002000000000000000000c9",
+    "address": "0x514f35a92a13bc7093f299af5d8ebb1387e42d6b",
+    "symbol": "B-80TEMP-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1637247862,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xa36fdbbae3c9d55a1d67ee5821d53b50b63a1ab9",
+        "symbol": "TEMP",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x6ae5a7857aad26722cb02cc168e38c52e0e4e45d0000000000000000000005dd",
+    "address": "0x6ae5a7857aad26722cb02cc168e38c52e0e4e45d",
+    "symbol": "TBY-feb1924-USDC-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1693245515,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x6ae5a7857aad26722cb02cc168e38c52e0e4e45d",
+        "symbol": "TBY-feb1924-USDC-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc4cafefbc3dfea629c589728d648cb6111db3136.png",
+        "address": "0xc4cafefbc3dfea629c589728d648cb6111db3136",
+        "symbol": "TBY-feb1924",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x52b69d6b3eb0bd6b2b4a48a316dfb0e1460e67e40002000000000000000005f3",
+    "address": "0x52b69d6b3eb0bd6b2b4a48a316dfb0e1460e67e4",
+    "symbol": "ECLP-R-sDAI",
+    "type": "GYROE",
+    "addedTimestamp": 1695206147,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x183015a9ba6ff60230fdeadc3f43b3d788b13e21.png",
+        "address": "0x183015a9ba6ff60230fdeadc3f43b3d788b13e21",
+        "symbol": "R",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x83f20f44975d03b1b09e64809b757c47f942beea.png",
+        "address": "0x83f20f44975d03b1b09e64809b757c47f942beea",
+        "symbol": "sDAI",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xfd1cf6fd41f229ca86ada0584c63c49c3d66bbc9000200000000000000000438",
+    "address": "0xfd1cf6fd41f229ca86ada0584c63c49c3d66bbc9",
+    "symbol": "50PENDLE-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1674522887,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x808507121b80c02388fad14726482e061b8da827.png",
+        "address": "0x808507121b80c02388fad14726482e061b8da827",
+        "symbol": "PENDLE",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc56000000000000000000000066",
+    "address": "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc56",
+    "symbol": "staBAL3-BTC",
+    "type": "STABLE",
+    "addedTimestamp": 1625662646,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "symbol": "WBTC",
+        "weight": null
+      },
+      {
+        "address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
+        "symbol": "renBTC",
+        "weight": null
+      },
+      {
+        "address": "0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6",
+        "symbol": "sBTC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x50cf90b954958480b8df7958a9e965752f62712400000000000000000000046f",
+    "address": "0x50cf90b954958480b8df7958a9e965752f627124",
+    "symbol": "bb-euler-USD-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1675954271,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x3c640f0d3036ad85afa2d5a9e32be651657b874f",
+        "symbol": "bb-e-USDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x50cf90b954958480b8df7958a9e965752f627124.png",
+        "address": "0x50cf90b954958480b8df7958a9e965752f627124",
+        "symbol": "bb-euler-USD-BPT",
+        "weight": null
+      },
+      {
+        "address": "0xd4e7c1f3da1144c9e2cfd1b015eda7652b4a4399",
+        "symbol": "bb-e-USDC",
+        "weight": null
+      },
+      {
+        "address": "0xeb486af868aeb3b6e53066abc9623b1041b42bc0",
+        "symbol": "bb-e-DAI",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x1a44e35d5451e0b78621a1b3e7a53dfaa306b1d000000000000000000000051b",
+    "address": "0x1a44e35d5451e0b78621a1b3e7a53dfaa306b1d0",
+    "symbol": "B-baoETH-ETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1681544303,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x1a44e35d5451e0b78621a1b3e7a53dfaa306b1d0",
+        "symbol": "B-baoETH-ETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "",
+        "address": "0xf4edfad26ee0d23b69ca93112ecce52704e0006f",
+        "symbol": "baoETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x08775ccb6674d6bdceb0797c364c2653ed84f3840002000000000000000004f0",
+    "address": "0x08775ccb6674d6bdceb0797c364c2653ed84f384",
+    "symbol": "50WETH-50-3pool",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1680364331,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x79c58f70905f734641735bc61e45c19dd9ad60bc.png",
+        "address": "0x79c58f70905f734641735bc61e45c19dd9ad60bc",
+        "symbol": "USDC-DAI-USDT",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x133d241f225750d2c92948e464a5a80111920331000000000000000000000476",
+    "address": "0x133d241f225750d2c92948e464a5a80111920331",
+    "symbol": "DOLA-bb-e-USD-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1675961423,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x133d241f225750d2c92948e464a5a80111920331",
+        "symbol": "DOLA-bb-e-USD-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x50cf90b954958480b8df7958a9e965752f627124.png",
+        "address": "0x50cf90b954958480b8df7958a9e965752f627124",
+        "symbol": "bb-euler-USD-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x865377367054516e17014ccded1e7d814edc9ce4.png",
+        "address": "0x865377367054516e17014ccded1e7d814edc9ce4",
+        "symbol": "DOLA",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xbaeec99c90e3420ec6c1e7a769d2a856d2898e4d00020000000000000000008a",
+    "address": "0xbaeec99c90e3420ec6c1e7a769d2a856d2898e4d",
+    "symbol": "B-50VITA-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1631291082,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321.png",
+        "address": "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+        "symbol": "VITA",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xde8c195aa41c11a0c4787372defbbddaa31306d2000200000000000000000181",
+    "address": "0xde8c195aa41c11a0c4787372defbbddaa31306d2",
+    "symbol": "50COW-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1648476917,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab.png",
+        "address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+        "symbol": "COW",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x26cc136e9b8fd65466f193a8e5710661ed9a98270002000000000000000005ad",
+    "address": "0x26cc136e9b8fd65466f193a8e5710661ed9a9827",
+    "symbol": "80BETS/20wstETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1690400639,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x94025780a1ab58868d9b2dbbb775f44b32e8e6e5.png",
+        "address": "0x94025780a1ab58868d9b2dbbb775f44b32e8e6e5",
+        "symbol": "BETS",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x9c6d47ff73e0f5e51be5fd53236e3f595c5793f200020000000000000000042c",
+    "address": "0x9c6d47ff73e0f5e51be5fd53236e3f595c5793f2",
+    "symbol": "B-cbETH-wstETH-Stable",
+    "type": "METASTABLE",
+    "addedTimestamp": 1673459963,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbe9895146f7af43049ca1c1ae358b0541ea49704.png",
+        "address": "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
+        "symbol": "cbETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x02d928e68d8f10c0358566152677db51e1e2dc8c00000000000000000000051e",
+    "address": "0x02d928e68d8f10c0358566152677db51e1e2dc8c",
+    "symbol": "swETH-bb-a-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1681569515,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x02d928e68d8f10c0358566152677db51e1e2dc8c",
+        "symbol": "swETH-bb-a-WETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x60d604890feaa0b5460b28a424407c24fe89374a.png",
+        "address": "0x60d604890feaa0b5460b28a424407c24fe89374a",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf951e335afb289353dc249e82926178eac7ded78.png",
+        "address": "0xf951e335afb289353dc249e82926178eac7ded78",
+        "symbol": "swETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8000200000000000000000019",
+    "address": "0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8",
+    "symbol": "B-50USDC-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1620156607,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x8167a1117691f39e05e9131cfa88f0e3a620e96700020000000000000000038c",
+    "address": "0x8167a1117691f39e05e9131cfa88f0e3a620e967",
+    "symbol": "20WETH-80T",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1665238895,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xcdf7028ceab81fa0c6971208e83fa7872994bee5.png",
+        "address": "0xcdf7028ceab81fa0c6971208e83fa7872994bee5",
+        "symbol": "T",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xad0e5e0778cac28f1ff459602b31351871b5754a0002000000000000000003ce",
+    "address": "0xad0e5e0778cac28f1ff459602b31351871b5754a",
+    "symbol": "BPT",
+    "type": "FX",
+    "addedTimestamp": 1668652895,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/5164/large/EURS_300x300.png?1550571779",
+        "address": "0xdb25f211ab05b1c97d595516f45794528a807ad8",
+        "symbol": "EURS",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xe8cc7e765647625b95f59c15848379d10b9ab4af0002000000000000000001de",
+    "address": "0xe8cc7e765647625b95f59c15848379d10b9ab4af",
+    "symbol": "20WETH-80WNCG",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1651547459,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf203ca1769ca8e9e8fe1da9d147db68b6c919817.png",
+        "address": "0xf203ca1769ca8e9e8fe1da9d147db68b6c919817",
+        "symbol": "WNCG",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x7d98f308db99fdd04bbf4217a4be8809f38faa6400020000000000000000059b",
+    "address": "0x7d98f308db99fdd04bbf4217a4be8809f38faa64",
+    "symbol": "80wstETH/20GHO",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1689434447,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/30663/large/ghoaave.jpeg?1686151372",
+        "address": "0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f",
+        "symbol": "GHO",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xb721a3b209f8b598b926826f69280bee7a6bb79600010000000000000000037c",
+    "address": "0xb721a3b209f8b598b926826f69280bee7a6bb796",
+    "symbol": "10RAI-6FLX-3rETH-26WETH-55RPL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1664285963,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x03ab458634910aad20ef5f1c8ee96f1d6ac54919",
+        "symbol": "RAI",
+        "weight": "0.1"
+      },
+      {
+        "address": "0x6243d8cea23066d098a15582d81a598b4e8391f4",
+        "symbol": "FLX",
+        "weight": "0.063"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png",
+        "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+        "symbol": "rETH",
+        "weight": "0.03"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.257"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd33526068d116ce69f19a9ee46f0bd304f21a51f.png",
+        "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+        "symbol": "RPL",
+        "weight": "0.55"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x42fbd9f666aacc0026ca1b88c94259519e03dd67000200000000000000000507",
+    "address": "0x42fbd9f666aacc0026ca1b88c94259519e03dd67",
+    "symbol": "50COIL-50USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1680729107,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x823e1b82ce1dc147bbdb25a203f046afab1ce918.png",
+        "address": "0x823e1b82ce1dc147bbdb25a203f046afab1ce918",
+        "symbol": "COIL",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xefdc9246e0c4280fb1c138e1093a95ab88959cf80002000000000000000000b9",
+    "address": "0xefdc9246e0c4280fb1c138e1093a95ab88959cf8",
+    "symbol": "B-80ENS-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1636477437,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+        "symbol": "ENS",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x79c58f70905f734641735bc61e45c19dd9ad60bc0000000000000000000004e7",
+    "address": "0x79c58f70905f734641735bc61e45c19dd9ad60bc",
+    "symbol": "USDC-DAI-USDT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1679700419,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x79c58f70905f734641735bc61e45c19dd9ad60bc.png",
+        "address": "0x79c58f70905f734641735bc61e45c19dd9ad60bc",
+        "symbol": "USDC-DAI-USDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        "symbol": "USDT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x92a6a387add0528463b69efc063708870483986a0002000000000000000001cf",
+    "address": "0x92a6a387add0528463b69efc063708870483986a",
+    "symbol": "BALLOON_LBP",
+    "type": "LIQUIDITYBOOTSTRAPPING",
+    "addedTimestamp": 1650950647,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x0146714490ae3c9b1c4b68d96b4c6a1ba0f38949",
+        "symbol": "BALLOON",
+        "weight": "0.988185145605575664"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.011830113648722775"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x67f117350eab45983374f4f83d275d8a5d62b1bf0001000000000000000004f2",
+    "address": "0x67f117350eab45983374f4f83d275d8a5d62b1bf",
+    "symbol": "OG",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1680406619,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x6f9c26fa731c7ea4139fa669962cf8f1ce6c8b0b",
+        "symbol": "OATH",
+        "weight": "0.35"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.15"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.15"
+      },
+      {
+        "address": "0xf88baf18fab7e330fa0c4f83949e23f52fececce",
+        "symbol": "GRAIN",
+        "weight": "0.35"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x0b09dea16768f0799065c475be02919503cb2a3500020000000000000000001a",
+    "address": "0x0b09dea16768f0799065c475be02919503cb2a35",
+    "symbol": "B-60WETH-40DAI",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1620156813,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "weight": "0.4"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.6"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x0578292cb20a443ba1cde459c985ce14ca2bdee5000100000000000000000269",
+    "address": "0x0578292cb20a443ba1cde459c985ce14ca2bdee5",
+    "symbol": "33auraBAL-33graviAURA-33WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1655903969,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x616e8bfa43f920657b3497dbf40d6b1a02d4608d.png",
+        "address": "0x616e8bfa43f920657b3497dbf40d6b1a02d4608d",
+        "symbol": "auraBAL",
+        "weight": "0.3333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba485b556399123261a5f9c95d413b4f93107407.png",
+        "address": "0xba485b556399123261a5f9c95d413b4f93107407",
+        "symbol": "graviAURA",
+        "weight": "0.3334"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.3333"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xc4451498f950b8b3abd9a815cf221a8e647913880001000000000000000001ea",
+    "address": "0xc4451498f950b8b3abd9a815cf221a8e64791388",
+    "symbol": "10LUSD-6LQTY-3rETH-26WETH-55RPL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1652020261,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5f98805a4e8be255a32880fdec7f6728c6568ba0.png",
+        "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+        "symbol": "LUSD",
+        "weight": "0.1"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d.png",
+        "address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
+        "symbol": "LQTY",
+        "weight": "0.063"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png",
+        "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+        "symbol": "rETH",
+        "weight": "0.03"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.257"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd33526068d116ce69f19a9ee46f0bd304f21a51f.png",
+        "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+        "symbol": "RPL",
+        "weight": "0.55"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x4cbde5c4b4b53ebe4af4adb85404725985406163000000000000000000000595",
+    "address": "0x4cbde5c4b4b53ebe4af4adb85404725985406163",
+    "symbol": "B-ETHx/bb-a-WETH ",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689175655,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x4cbde5c4b4b53ebe4af4adb85404725985406163",
+        "symbol": "B-ETHx/bb-a-WETH ",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/30870/large/ETHx-small.png?1688373266",
+        "address": "0xa35b1b31ce002fbf2058d22f30f95d405200a15b",
+        "symbol": "ETHx",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/31285/large/eth-diamond-black-gray.png?1692194016",
+        "address": "0xbb6881874825e60e1160416d6c426eae65f2459e",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xaac98ee71d4f8a156b6abaa6844cdb7789d086ce00020000000000000000001b",
+    "address": "0xaac98ee71d4f8a156b6abaa6844cdb7789d086ce",
+    "symbol": "B-60MKR-40WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1620157553,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+        "symbol": "",
+        "weight": "0.6"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.4"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xd4e7c1f3da1144c9e2cfd1b015eda7652b4a439900000000000000000000046a",
+    "address": "0xd4e7c1f3da1144c9e2cfd1b015eda7652b4a4399",
+    "symbol": "bb-e-USDC",
+    "type": "EULERLINEAR",
+    "addedTimestamp": 1675908515,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "address": "0xd4e7c1f3da1144c9e2cfd1b015eda7652b4a4399",
+        "symbol": "bb-e-USDC",
+        "weight": null
+      },
+      {
+        "address": "0xeb91861f8a4e1c12333f42dce8fb0ecdc28da716",
+        "symbol": "eUSDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x36be1e97ea98ab43b4debf92742517266f5731a3000200000000000000000466",
+    "address": "0x36be1e97ea98ab43b4debf92742517266f5731a3",
+    "symbol": "50wstETH-50ACX",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1675902863,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f.png",
+        "address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
+        "symbol": "ACX",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xbb6881874825e60e1160416d6c426eae65f2459e000000000000000000000592",
+    "address": "0xbb6881874825e60e1160416d6c426eae65f2459e",
+    "symbol": "bb-a-WETH",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1689171071,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x03928473f25bb2da6bc880b07ecbadc636822264",
+        "symbol": "stataEthWETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/31285/large/eth-diamond-black-gray.png?1692194016",
+        "address": "0xbb6881874825e60e1160416d6c426eae65f2459e",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xae8535c23afedda9304b03c68a3563b75fc8f92b0000000000000000000005a0",
+    "address": "0xae8535c23afedda9304b03c68a3563b75fc8f92b",
+    "symbol": "swETH-bb-a-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689520463,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xae8535c23afedda9304b03c68a3563b75fc8f92b",
+        "symbol": "swETH-bb-a-WETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/31285/large/eth-diamond-black-gray.png?1692194016",
+        "address": "0xbb6881874825e60e1160416d6c426eae65f2459e",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf951e335afb289353dc249e82926178eac7ded78.png",
+        "address": "0xf951e335afb289353dc249e82926178eac7ded78",
+        "symbol": "swETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x18fdf15ff782e44c1f9b6c5846ff6b0f0004f6a2000200000000000000000560",
+    "address": "0x18fdf15ff782e44c1f9b6c5846ff6b0f0004f6a2",
+    "symbol": "50OHM-50LUSD",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1685952995,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5f98805a4e8be255a32880fdec7f6728c6568ba0.png",
+        "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+        "symbol": "LUSD",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png",
+        "address": "0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5",
+        "symbol": "OHM",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xeb486af868aeb3b6e53066abc9623b1041b42bc000000000000000000000046c",
+    "address": "0xeb486af868aeb3b6e53066abc9623b1041b42bc0",
+    "symbol": "bb-e-DAI",
+    "type": "EULERLINEAR",
+    "addedTimestamp": 1675908635,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "weight": null
+      },
+      {
+        "address": "0xe025e3ca2be02316033184551d4d3aa22024d9dc",
+        "symbol": "eDAI",
+        "weight": null
+      },
+      {
+        "address": "0xeb486af868aeb3b6e53066abc9623b1041b42bc0",
+        "symbol": "bb-e-DAI",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xd4f79ca0ac83192693bce4699d0c10c66aa6cf0f00020000000000000000047e",
+    "address": "0xd4f79ca0ac83192693bce4699d0c10c66aa6cf0f",
+    "symbol": "OHM-wstETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1676060687,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png",
+        "address": "0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5",
+        "symbol": "OHM",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x93ab2afded588a9e7f3ef569834b13685d612f96000200000000000000000095",
+    "address": "0x93ab2afded588a9e7f3ef569834b13685d612f96",
+    "symbol": "80M2-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1632085383,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x965d79f1a1016b574a62986e13ca8ab04dfdd15c",
+        "symbol": "M2",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x072f14b85add63488ddad88f855fda4a99d6ac9b000200000000000000000027",
+    "address": "0x072f14b85add63488ddad88f855fda4a99d6ac9b",
+    "symbol": "B-50SNX-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1620161839,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png",
+        "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+        "symbol": "SNX",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x2e848426aec6dbf2260535a5bea048ed94d9ff3d000000000000000000000536",
+    "address": "0x2e848426aec6dbf2260535a5bea048ed94d9ff3d",
+    "symbol": "wbETH-wstETH",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1683201371,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x2e848426aec6dbf2260535a5bea048ed94d9ff3d",
+        "symbol": "wbETH-wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/30061/large/wbeth-icon.png?1683001548",
+        "address": "0xa2e3356610840701bdf5611a53974510ae27e2e1",
+        "symbol": "wBETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x798b112420ad6391a4129ac25ef59663a44c88bb0002000000000000000003f4",
+    "address": "0x798b112420ad6391a4129ac25ef59663a44c88bb",
+    "symbol": "wstETH-ACX",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1669644575,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f.png",
+        "address": "0x44108f0223a3c3028f5fe7aec7f9bb2e66bef82f",
+        "symbol": "ACX",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xb54e6aadbf1ac1a3ef2a56e358706f0f8e320a0300000000000000000000059f",
+    "address": "0xb54e6aadbf1ac1a3ef2a56e358706f0f8e320a03",
+    "symbol": "vETH/WETH BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689519911,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4bc3263eb5bb2ef7ad9ab6fb68be80e43b43801f.png",
+        "address": "0x4bc3263eb5bb2ef7ad9ab6fb68be80e43b43801f",
+        "symbol": "vETH",
+        "weight": null
+      },
+      {
+        "address": "0xb54e6aadbf1ac1a3ef2a56e358706f0f8e320a03",
+        "symbol": "vETH/WETH BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x3e09e828c716c5e2bc5034eed7d5ec8677ffba180002000000000000000002b1",
+    "address": "0x3e09e828c716c5e2bc5034eed7d5ec8677ffba18",
+    "symbol": "80MPH-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1657812209,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x8888801af4d980682e47f1a9036e589479e835c5",
+        "symbol": "MPH",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xf506984c16737b1a9577cadeda02a49fd612aff80002000000000000000002a9",
+    "address": "0xf506984c16737b1a9577cadeda02a49fd612aff8",
+    "symbol": "50XAI-50USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1657603411,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x35e78b3982e87ecfd5b3f3265b601c046cdbe232",
+        "symbol": "XAI",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x70d5e3234f6329c1d5a26796dcf4e109d69a34880000000000000000000005e7",
+    "address": "0x70d5e3234f6329c1d5a26796dcf4e109d69a3488",
+    "symbol": "uniETH/wstETH/rETH",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1693833479,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x70d5e3234f6329c1d5a26796dcf4e109d69a3488",
+        "symbol": "uniETH/wstETH/rETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png",
+        "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+        "symbol": "rETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf1376bcef0f78459c0ed0ba5ddce976f1ddf51f4.png",
+        "address": "0xf1376bcef0f78459c0ed0ba5ddce976f1ddf51f4",
+        "symbol": "uniETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xe4e72f872c4048925a78e1e6fddac411c9ae348a0000000000000000000005bc",
+    "address": "0xe4e72f872c4048925a78e1e6fddac411c9ae348a",
+    "symbol": "2BTC",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1691729291,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1674474504",
+        "address": "0x18084fba666a33d37592fa2633fd49a74dd93a88",
+        "symbol": "tBTC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "symbol": "WBTC",
+        "weight": null
+      },
+      {
+        "address": "0xe4e72f872c4048925a78e1e6fddac411c9ae348a",
+        "symbol": "2BTC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x3c640f0d3036ad85afa2d5a9e32be651657b874f00000000000000000000046b",
+    "address": "0x3c640f0d3036ad85afa2d5a9e32be651657b874f",
+    "symbol": "bb-e-USDT",
+    "type": "EULERLINEAR",
+    "addedTimestamp": 1675908575,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x3c640f0d3036ad85afa2d5a9e32be651657b874f",
+        "symbol": "bb-e-USDT",
+        "weight": null
+      },
+      {
+        "address": "0x4d19f33948b99800b6113ff3e83bec9b537c85d2",
+        "symbol": "eUSDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        "symbol": "USDT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x7e9afd25f5ec0eb24d7d4b089ae7ecb9651c8b1f000000000000000000000511",
+    "address": "0x7e9afd25f5ec0eb24d7d4b089ae7ecb9651c8b1f",
+    "symbol": "B-baoUSD-LUSD-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1681222379,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5f98805a4e8be255a32880fdec7f6728c6568ba0.png",
+        "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+        "symbol": "LUSD",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/28592/large/baoUSD.png?1672191676",
+        "address": "0x7945b0a6674b175695e5d1d08ae1e6f13744abb0",
+        "symbol": "BaoUSD",
+        "weight": null
+      },
+      {
+        "address": "0x7e9afd25f5ec0eb24d7d4b089ae7ecb9651c8b1f",
+        "symbol": "B-baoUSD-LUSD-BPT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xdf2c03c12442c7a0895455a48569b889079ca52a000200000000000000000538",
+    "address": "0xdf2c03c12442c7a0895455a48569b889079ca52a",
+    "symbol": "80ARCH-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1683242339,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x73c69d24ad28e2d43d03cbf35f79fe26ebde1011.png",
+        "address": "0x73c69d24ad28e2d43d03cbf35f79fe26ebde1011",
+        "symbol": "ARCH",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x034e2d995b39a88ab9a532a9bf0deddac2c576ea0002000000000000000005d1",
+    "address": "0x034e2d995b39a88ab9a532a9bf0deddac2c576ea",
+    "symbol": "80SD-20ETHx",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1692575471,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x30d20208d987713f46dfd34ef128bb16c404d10f.png",
+        "address": "0x30d20208d987713f46dfd34ef128bb16c404d10f",
+        "symbol": "SD",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/30870/large/ETHx-small.png?1688373266",
+        "address": "0xa35b1b31ce002fbf2058d22f30f95d405200a15b",
+        "symbol": "ETHx",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x41503c9d499ddbd1dcdf818a1b05e9774203bf46000000000000000000000594",
+    "address": "0x41503c9d499ddbd1dcdf818a1b05e9774203bf46",
+    "symbol": "wstETH-bb-a-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689173579,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x41503c9d499ddbd1dcdf818a1b05e9774203bf46",
+        "symbol": "wstETH-bb-a-WETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/31285/large/eth-diamond-black-gray.png?1692194016",
+        "address": "0xbb6881874825e60e1160416d6c426eae65f2459e",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x441b8a1980f2f2e43a9397099d15cc2fe6d3625000020000000000000000035f",
+    "address": "0x441b8a1980f2f2e43a9397099d15cc2fe6d36250",
+    "symbol": "50INV-50DOLA",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1662599795,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x41d5d79431a913c4ae7d69a668ecdfe5ff9dfb68.png",
+        "address": "0x41d5d79431a913c4ae7d69a668ecdfe5ff9dfb68",
+        "symbol": "INV",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x865377367054516e17014ccded1e7d814edc9ce4.png",
+        "address": "0x865377367054516e17014ccded1e7d814edc9ce4",
+        "symbol": "DOLA",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xbfce47224b4a938865e3e2727dc34e0faa5b1d82000000000000000000000527",
+    "address": "0xbfce47224b4a938865e3e2727dc34e0faa5b1d82",
+    "symbol": "uniETH-WETH",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1682117411,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xbfce47224b4a938865e3e2727dc34e0faa5b1d82",
+        "symbol": "uniETH-WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf1376bcef0f78459c0ed0ba5ddce976f1ddf51f4.png",
+        "address": "0xf1376bcef0f78459c0ed0ba5ddce976f1ddf51f4",
+        "symbol": "uniETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xe99481dc77691d8e2456e5f3f61c1810adfc1503000200000000000000000018",
+    "address": "0xe99481dc77691d8e2456e5f3f61c1810adfc1503",
+    "symbol": "B-50LINK-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1620156455,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
+        "symbol": "LINK",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x2d011adf89f0576c9b722c28269fcb5d50c2d17900020000000000000000024d",
+    "address": "0x2d011adf89f0576c9b722c28269fcb5d50c2d179",
+    "symbol": "B-sdBAL-STABLE",
+    "type": "STABLE",
+    "addedTimestamp": 1655279564,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5c6ee304399dbdb9c8ef030ab642b10820db8f56.png",
+        "address": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56",
+        "symbol": "B-80BAL-20WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf24d8651578a55b0c119b9910759a351a3458895.png",
+        "address": "0xf24d8651578a55b0c119b9910759a351a3458895",
+        "symbol": "sdBal",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x5f1f4e50ba51d723f12385a8a9606afc3a0555f5000200000000000000000465",
+    "address": "0x5f1f4e50ba51d723f12385a8a9606afc3a0555f5",
+    "symbol": "50wstETH-50LDO",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1675902395,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5a98fcbea516cf06857215779fd812ca3bef1b32.png",
+        "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+        "symbol": "LDO",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x9137f3a026fa419a7a9a0ba8df6601d4b0abfd260002000000000000000001ab",
+    "address": "0x9137f3a026fa419a7a9a0ba8df6601d4b0abfd26",
+    "symbol": "BBPT",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1650455960,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xf17e65822b568b3903685a7c9f496cf7656cc6c2",
+        "symbol": "BICO",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x27c9f71cc31464b906e0006d4fcbc8900f48f15f00020000000000000000010f",
+    "address": "0x27c9f71cc31464b906e0006d4fcbc8900f48f15f",
+    "symbol": "80D2D-20USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1639761033,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad.png",
+        "address": "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad",
+        "symbol": "D2D",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xf8c4cd95c7496cb7c8d97202cf7e5b8da2204c2b00020000000000000000039e",
+    "address": "0xf8c4cd95c7496cb7c8d97202cf7e5b8da2204c2b",
+    "symbol": "80psdnOCEAN-20OCEAN",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1666003559,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x51fa2efd62ee56a493f24ae963eace7d0051929e",
+        "symbol": "psdnOCEAN",
+        "weight": "0.8"
+      },
+      {
+        "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
+        "symbol": "OCEAN",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x380aabe019ed2a9c2d632b51eddd30fd804d0fad000200000000000000000554",
+    "address": "0x380aabe019ed2a9c2d632b51eddd30fd804d0fad",
+    "symbol": "50R-50wstETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1684846547,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x183015a9ba6ff60230fdeadc3f43b3d788b13e21.png",
+        "address": "0x183015a9ba6ff60230fdeadc3f43b3d788b13e21",
+        "symbol": "R",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xb704aa724e69601ffdc9b748137491bffa1b858d0001000000000000000004a1",
+    "address": "0xb704aa724e69601ffdc9b748137491bffa1b858d",
+    "symbol": "33QOM-33O-33CAW",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1676725091,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xa71d0588eaf47f12b13cf8ec750430d21df04974",
+        "symbol": "QOM",
+        "weight": "0.3333"
+      },
+      {
+        "address": "0xb53ecf1345cabee6ea1a65100ebb153cebcac40f",
+        "symbol": "O",
+        "weight": "0.3334"
+      },
+      {
+        "address": "0xf3b9569f82b18aef890de263b84189bd33ebe452",
+        "symbol": "CAW",
+        "weight": "0.3333"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x1bccaac02bae336c6352acc3b772059ef1142fa70002000000000000000001f0",
+    "address": "0x1bccaac02bae336c6352acc3b772059ef1142fa7",
+    "symbol": "50XNS-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1652493695,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x79c71d3436f39ce382d0f58f1b011d88100b9d91",
+        "symbol": "XNS",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x60d604890feaa0b5460b28a424407c24fe89374a0000000000000000000004fc",
+    "address": "0x60d604890feaa0b5460b28a424407c24fe89374a",
+    "symbol": "bb-a-WETH",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1680633155,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x59463bb67ddd04fe58ed291ba36c26d99a39fbc6",
+        "symbol": "waWETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x60d604890feaa0b5460b28a424407c24fe89374a.png",
+        "address": "0x60d604890feaa0b5460b28a424407c24fe89374a",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063",
+    "address": "0x06df3b2bbb68adc8b0e302443692037ed9f91b42",
+    "symbol": "staBAL3",
+    "type": "STABLE",
+    "addedTimestamp": 1625518360,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        "symbol": "USDT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x87a867f5d240a782d43d90b6b06dea470f3f8f22000200000000000000000516",
+    "address": "0x87a867f5d240a782d43d90b6b06dea470f3f8f22",
+    "symbol": "B-50COMP-50wstETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1681328963,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png",
+        "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+        "symbol": "COMP",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x1ed17e0a220ff56d6561c4929f2e4f7088d365d30002000000000000000005fa",
+    "address": "0x1ed17e0a220ff56d6561c4929f2e4f7088d365d3",
+    "symbol": "MOQ_F9_LBP",
+    "type": "LIQUIDITYBOOTSTRAPPING",
+    "addedTimestamp": 1696368923,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x867172de8ad0f66e9591860be18f40eb00068159",
+        "symbol": "MOQ",
+        "weight": "0.915762747854250601"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.084252511382841217"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xbe19d87ea6cd5b05bbc34b564291c371dae967470000000000000000000005c4",
+    "address": "0xbe19d87ea6cd5b05bbc34b564291c371dae96747",
+    "symbol": "GHO-3POOL-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692108155,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/30663/large/ghoaave.jpeg?1686151372",
+        "address": "0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f",
+        "symbol": "GHO",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x79c58f70905f734641735bc61e45c19dd9ad60bc.png",
+        "address": "0x79c58f70905f734641735bc61e45c19dd9ad60bc",
+        "symbol": "USDC-DAI-USDT",
+        "weight": null
+      },
+      {
+        "address": "0xbe19d87ea6cd5b05bbc34b564291c371dae96747",
+        "symbol": "GHO-3POOL-BPT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xdbc4f138528b6b893cbcc3fd9c15d8b34d0554ae0002000000000000000003bf",
+    "address": "0xdbc4f138528b6b893cbcc3fd9c15d8b34d0554ae",
+    "symbol": "85QNT-15USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1667642411,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x4a220e6096b25eadb88358cb44068a3248254675",
+        "symbol": "QNT",
+        "weight": "0.85"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.15"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x5d6e3d7632d6719e04ca162be652164bec1eaa6b000200000000000000000048",
+    "address": "0x5d6e3d7632d6719e04ca162be652164bec1eaa6b",
+    "symbol": "PAR50-USDC50",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1623924592,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+        "symbol": "PAR",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xfebb0bbf162e64fb9d0dfe186e517d84c395f016000000000000000000000502",
+    "address": "0xfebb0bbf162e64fb9d0dfe186e517d84c395f016",
+    "symbol": "bb-a-USD",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1680683795,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6667c6fa9f2b3fc1cc8d85320b62703d938e4385.png",
+        "address": "0x6667c6fa9f2b3fc1cc8d85320b62703d938e4385",
+        "symbol": "bb-a-DAI",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xa1697f9af0875b63ddc472d6eebada8c1fab8568.png",
+        "address": "0xa1697f9af0875b63ddc472d6eebada8c1fab8568",
+        "symbol": "bb-a-USDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xcbfa4532d8b2ade2c261d3dd5ef2a2284f792692.png",
+        "address": "0xcbfa4532d8b2ade2c261d3dd5ef2a2284f792692",
+        "symbol": "bb-a-USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfebb0bbf162e64fb9d0dfe186e517d84c395f016.png",
+        "address": "0xfebb0bbf162e64fb9d0dfe186e517d84c395f016",
+        "symbol": "bb-a-USD",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xe0e8ac08de6708603cfd3d23b613d2f80e3b7afb00020000000000000000058a",
+    "address": "0xe0e8ac08de6708603cfd3d23b613d2f80e3b7afb",
+    "symbol": "ECLP-wstETH-swETH",
+    "type": "GYROE",
+    "addedTimestamp": 1689110147,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf951e335afb289353dc249e82926178eac7ded78.png",
+        "address": "0xf951e335afb289353dc249e82926178eac7ded78",
+        "symbol": "swETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x3ebf48cd7586d7a4521ce59e53d9a907ebf1480f000200000000000000000028",
+    "address": "0x3ebf48cd7586d7a4521ce59e53d9a907ebf1480f",
+    "symbol": "B-50BAL-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1620162057,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba100000625a3754423978a60c9317c58a424e3d.png",
+        "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+        "symbol": "BAL",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xd5d99b7e9697ba8bb1da48f07ba81900c7572cea0000000000000000000005cc",
+    "address": "0xd5d99b7e9697ba8bb1da48f07ba81900c7572cea",
+    "symbol": "DUSD-3POOL-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692371747,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x79c58f70905f734641735bc61e45c19dd9ad60bc.png",
+        "address": "0x79c58f70905f734641735bc61e45c19dd9ad60bc",
+        "symbol": "USDC-DAI-USDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xa48f322f8b3edff967629af79e027628b9dd1298.png",
+        "address": "0xa48f322f8b3edff967629af79e027628b9dd1298",
+        "symbol": "DUSD",
+        "weight": null
+      },
+      {
+        "address": "0xd5d99b7e9697ba8bb1da48f07ba81900c7572cea",
+        "symbol": "DUSD-3POOL-BPT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xe4010ef5e37dc23154680f23c4a0d48bfca91687000200000000000000000432",
+    "address": "0xe4010ef5e37dc23154680f23c4a0d48bfca91687",
+    "symbol": "80SD-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1674054971,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x30d20208d987713f46dfd34ef128bb16c404d10f.png",
+        "address": "0x30d20208d987713f46dfd34ef128bb16c404d10f",
+        "symbol": "SD",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x3f7c10701b14197e2695dec6428a2ca4cf7fc3b800020000000000000000023c",
+    "address": "0x3f7c10701b14197e2695dec6428a2ca4cf7fc3b8",
+    "symbol": "50DFX-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1654880110,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x888888435fde8e7d4c54cab67f206e4199454c60.png",
+        "address": "0x888888435fde8e7d4c54cab67f206e4199454c60",
+        "symbol": "DFX",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x081650db8297690b60a0fac6c32a304401653b7e000200000000000000000208",
+    "address": "0x081650db8297690b60a0fac6c32a304401653b7e",
+    "symbol": "LCH_LBP",
+    "type": "LIQUIDITYBOOTSTRAPPING",
+    "addedTimestamp": 1653429042,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x8d195f646b2834c2cde76952d5f30211a1f84036",
+        "symbol": "LCH",
+        "weight": "0.010009918364232853"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.990005340657663844"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x1b6e13673f29688e27311b332af1527f1ebf1d28000200000000000000000546",
+    "address": "0x1b6e13673f29688e27311b332af1527f1ebf1d28",
+    "symbol": "80PSDN-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1684137239,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xa5b947687163fe88c3e6af5b17ae69896f4abccf",
+        "symbol": "PSDN",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x6d39e85025fdc6fd7b1333454a2e18b873583f7c0002000000000000000001c5",
+    "address": "0x6d39e85025fdc6fd7b1333454a2e18b873583f7c",
+    "symbol": "ASTEROID_LBP",
+    "type": "LIQUIDITYBOOTSTRAPPING",
+    "addedTimestamp": 1650776237,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x72b734e6046304a78734937da869638e7e5b51d0",
+        "symbol": "ASTEROID",
+        "weight": "0.838843315471773027"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.161171943747043731"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x99a14324cfd525a34bbc93ac7e348929909d57fd00020000000000000000030e",
+    "address": "0x99a14324cfd525a34bbc93ac7e348929909d57fd",
+    "symbol": "50WETH-50FOLD",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1659997477,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd084944d3c05cd115c09d072b9f44ba3e0e45921.png",
+        "address": "0xd084944d3c05cd115c09d072b9f44ba3e0e45921",
+        "symbol": "FOLD",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xccf5575570fac94cec733a58ff91bb3d073085c70002000000000000000000af",
+    "address": "0xccf5575570fac94cec733a58ff91bb3d073085c7",
+    "symbol": "iROBOT",
+    "type": "INVESTMENT",
+    "addedTimestamp": 1635167734,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.300000000116415322"
+      },
+      {
+        "address": "0xfb5453340c03db5ade474b27e68b6a9c6b2823eb",
+        "symbol": "ROBOT",
+        "weight": "0.700000000116415322"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x7edde0cb05ed19e03a9a47cd5e53fc57fde1c80c0002000000000000000000c8",
+    "address": "0x7edde0cb05ed19e03a9a47cd5e53fc57fde1c80c",
+    "symbol": "LPePyvUSDC-29APR22",
+    "type": "ELEMENT",
+    "addedTimestamp": 1637084616,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x52c9886d5d87b0f06ebacbeff750b5ffad5d17d9",
+        "symbol": "ePyvUSDC-29APR22",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x8a34b5ad76f528bfec06c80d85ef3b53da7fc30000020000000000000000043e",
+    "address": "0x8a34b5ad76f528bfec06c80d85ef3b53da7fc300",
+    "symbol": "B-ankrETH-WETH-Stable",
+    "type": "METASTABLE",
+    "addedTimestamp": 1674754127,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe95a203b1a91a908f9b9ce46459d101078c2c3cb.png",
+        "address": "0xe95a203b1a91a908f9b9ce46459d101078c2c3cb",
+        "symbol": "ankrETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x186084ff790c65088ba694df11758fae4943ee9e000200000000000000000013",
+    "address": "0x186084ff790c65088ba694df11758fae4943ee9e",
+    "symbol": "B-50WETH-50YFI",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1620152748,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+        "symbol": "YFI",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x10a2f8bd81ee2898d7ed18fb8f114034a549fa59000200000000000000000090",
+    "address": "0x10a2f8bd81ee2898d7ed18fb8f114034a549fa59",
+    "symbol": "LPePyvUSDC-28JAN22",
+    "type": "ELEMENT",
+    "addedTimestamp": 1631632569,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x8a2228705ec979961f0e16df311debcf097a2766",
+        "symbol": "ePyvUSDC-28JAN22",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x87165b659ba7746907a48763063efa3b323c2b0700020000000000000000002d",
+    "address": "0x87165b659ba7746907a48763063efa3b323c2b07",
+    "symbol": "80BANK-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1621061137,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x2d94aa3e47d9d5024503ca8491fce9a2fb4da198",
+        "symbol": "BANK",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xa7ff759dbef9f3efdd1d59beee44b966acafe214000200000000000000000180",
+    "address": "0xa7ff759dbef9f3efdd1d59beee44b966acafe214",
+    "symbol": "USDC-PAL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1648309923,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xab846fb6c81370327e784ae7cbb6d6a6af6ff4bf.png",
+        "address": "0xab846fb6c81370327e784ae7cbb6d6a6af6ff4bf",
+        "symbol": "PAL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xa5533a44d06800eaf2daad5aad3f9aa9e1dc36140002000000000000000001b8",
+    "address": "0xa5533a44d06800eaf2daad5aad3f9aa9e1dc3614",
+    "symbol": "20PAR-80MIMO",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1650614923,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+        "symbol": "PAR",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x90b831fa3bebf58e9744a14d638e25b4ee06f9bc",
+        "symbol": "MIMO",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xa1697f9af0875b63ddc472d6eebada8c1fab85680000000000000000000004f9",
+    "address": "0xa1697f9af0875b63ddc472d6eebada8c1fab8568",
+    "symbol": "bb-a-USDT",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1680633035,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xa1697f9af0875b63ddc472d6eebada8c1fab8568.png",
+        "address": "0xa1697f9af0875b63ddc472d6eebada8c1fab8568",
+        "symbol": "bb-a-USDT",
+        "weight": null
+      },
+      {
+        "address": "0xa7e0e66f38b8ad8343cff67118c1f33e827d1455",
+        "symbol": "waUSDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        "symbol": "USDT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xea39581977325c0833694d51656316ef8a926a62000200000000000000000036",
+    "address": "0xea39581977325c0833694d51656316ef8a926a62",
+    "symbol": "75xSNXa-25WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1622560731,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x1cf0f3aabe4d12106b27ab44df5473974279c524",
+        "symbol": "xSNXa",
+        "weight": "0.75"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.25"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x0bf37157d30dfe6f56757dcadff01aed83b08cd600020000000000000000019a",
+    "address": "0x0bf37157d30dfe6f56757dcadff01aed83b08cd6",
+    "symbol": "80NATION-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1649860425,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x333a4823466879eef910a04d473505da62142069",
+        "symbol": "NATION",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xa02e4b3d18d4e6b8d18ac421fbc3dfff8933c40a00020000000000000000004b",
+    "address": "0xa02e4b3d18d4e6b8d18ac421fbc3dfff8933c40a",
+    "symbol": "B-50MATIC-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1623957298,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0/logo.png",
+        "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+        "symbol": "MATIC",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x90ca5cef5b29342b229fb8ae2db5d8f4f894d6520002000000000000000000b5",
+    "address": "0x90ca5cef5b29342b229fb8ae2db5d8f4f894d652",
+    "symbol": "LPePyvUSDC-17DEC21",
+    "type": "ELEMENT",
+    "addedTimestamp": 1635866643,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x76a34d72b9cf97d972fb0e390eb053a37f211c74",
+        "symbol": "ePyvUSDC-17DEC21",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xff083f57a556bfb3bbe46ea1b4fa154b2b1fbe88000200000000000000000030",
+    "address": "0xff083f57a556bfb3bbe46ea1b4fa154b2b1fbe88",
+    "symbol": "B-80GTC-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1621964533,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+        "symbol": "GTC",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xa47d1251cf21ad42685cc6b8b3a186a73dbd06cf000200000000000000000097",
+    "address": "0xa47d1251cf21ad42685cc6b8b3a186a73dbd06cf",
+    "symbol": "LPePyvDAI-28JAN22",
+    "type": "ELEMENT",
+    "addedTimestamp": 1632233996,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x449d7c2e096e9f867339078535b15440d42f78e8",
+        "symbol": "ePyvDAI-28JAN22",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xae7bfd6fa54259fc477879712eebe34164d3a84f000200000000000000000376",
+    "address": "0xae7bfd6fa54259fc477879712eebe34164d3a84f",
+    "symbol": "80palStkAAVE-20AAVE",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1663850723,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x24e79e946dea5482212c38aab2d0782f04cdb0e0.png",
+        "address": "0x24e79e946dea5482212c38aab2d0782f04cdb0e0",
+        "symbol": "palStkAAVE",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9/logo.png",
+        "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+        "symbol": "AAVE",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xc2a71921d945be82dc6371096300422c1cc422cf00020000000000000000019e",
+    "address": "0xc2a71921d945be82dc6371096300422c1cc422cf",
+    "symbol": "HOOT_LBP",
+    "type": "LIQUIDITYBOOTSTRAPPING",
+    "addedTimestamp": 1650166252,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x1be686d5be49a44bdaa1104d89509ad6860ab779",
+        "symbol": "HOOT",
+        "weight": "0.4"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.6"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xc88c76dd8b92408fe9bea1a54922a31e232d873c0002000000000000000005b2",
+    "address": "0xc88c76dd8b92408fe9bea1a54922a31e232d873c",
+    "symbol": "80ASX-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1691057747,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x67d85a291fcdc862a78812a3c26d55e28ffb2701",
+        "symbol": "ASX",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xbf96189eee9357a95c7719f4f5047f76bde804e5000200000000000000000087",
+    "address": "0xbf96189eee9357a95c7719f4f5047f76bde804e5",
+    "symbol": "B-80LDO-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1630613506,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5a98fcbea516cf06857215779fd812ca3bef1b32.png",
+        "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+        "symbol": "LDO",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x5512a4bbe7b3051f92324bacf25c02b9000c4a500001000000000000000003d7",
+    "address": "0x5512a4bbe7b3051f92324bacf25c02b9000c4a50",
+    "symbol": "33LUSD-33LQTY-33WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1668854231,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5f98805a4e8be255a32880fdec7f6728c6568ba0.png",
+        "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+        "symbol": "LUSD",
+        "weight": "0.3333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d.png",
+        "address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
+        "symbol": "LQTY",
+        "weight": "0.3333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.3334"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x8f4205e1604133d1875a3e771ae7e4f2b086563900020000000000000000010e",
+    "address": "0x8f4205e1604133d1875a3e771ae7e4f2b0865639",
+    "symbol": "50N/A-50N/A",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1639760602,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad.png",
+        "address": "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad",
+        "symbol": "D2D",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba100000625a3754423978a60c9317c58a424e3d.png",
+        "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+        "symbol": "BAL",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x382dc5b2eca1c1308eb7e2b40c0f571afb899ac8000100000000000000000557",
+    "address": "0x382dc5b2eca1c1308eb7e2b40c0f571afb899ac8",
+    "symbol": "14DNT-14WBTC-14VEE-14KEY-14SNT-14QSP-14WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1685133047,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x0abdace70d3790235af448c88547603b945604ea",
+        "symbol": "DNT",
+        "weight": "0.143"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "symbol": "WBTC",
+        "weight": "0.143"
+      },
+      {
+        "address": "0x340d2bde5eb28c1eed91b2f790723e3b160613b7",
+        "symbol": "VEE",
+        "weight": "0.143"
+      },
+      {
+        "address": "0x4cc19356f2d37338b9802aa8e8fc58b0373296e7",
+        "symbol": "KEY",
+        "weight": "0.143"
+      },
+      {
+        "address": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
+        "symbol": "SNT",
+        "weight": "0.143"
+      },
+      {
+        "address": "0x99ea4db9ee77acd40b119bd1dc4e33e1c070b80d",
+        "symbol": "QSP",
+        "weight": "0.143"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.142"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x0bbc7b78ff8453c40718e290b33f1d00ee67274e000000000000000000000563",
+    "address": "0x0bbc7b78ff8453c40718e290b33f1d00ee67274e",
+    "symbol": "B-bETH-ETHBP-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1686223583,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x0bbc7b78ff8453c40718e290b33f1d00ee67274e",
+        "symbol": "B-bETH-ETHBP-BPT",
+        "weight": null
+      },
+      {
+        "address": "0x1a44e35d5451e0b78621a1b3e7a53dfaa306b1d0",
+        "symbol": "B-baoETH-ETH-BPT",
+        "weight": null
+      },
+      {
+        "address": "0xa1e3f062ce5825c1e19207cd93cefdad82a8a631",
+        "symbol": "bETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x4edcb2b46377530bc18bb4d2c7fe46a992c73e100000000000000000000003ec",
+    "address": "0x4edcb2b46377530bc18bb4d2c7fe46a992c73e10",
+    "symbol": "cbETH-wstETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1669221107,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x4edcb2b46377530bc18bb4d2c7fe46a992c73e10",
+        "symbol": "cbETH-wstETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbe9895146f7af43049ca1c1ae358b0541ea49704.png",
+        "address": "0xbe9895146f7af43049ca1c1ae358b0541ea49704",
+        "symbol": "cbETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x8e9690e135005e415bd050b11768615de43fe5f8000200000000000000000043",
+    "address": "0x8e9690e135005e415bd050b11768615de43fe5f8",
+    "symbol": "50STR-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1623475310,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
+        "symbol": "STR",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x3b9fb87f7d081ceddb1289258fa5660d955317b6000200000000000000000544",
+    "address": "0x3b9fb87f7d081ceddb1289258fa5660d955317b6",
+    "symbol": "50B-baoETH-ETH-BPT-50BAO",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1683886487,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x1a44e35d5451e0b78621a1b3e7a53dfaa306b1d0",
+        "symbol": "B-baoETH-ETH-BPT",
+        "weight": "0.5"
+      },
+      {
+        "address": "0xce391315b414d4c7555956120461d21808a69f3a",
+        "symbol": "BAO",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x8ed9e70bfa17a1e2c4f8e561c8d0c2d1acc092fa0001000000000000000005ce",
+    "address": "0x8ed9e70bfa17a1e2c4f8e561c8d0c2d1acc092fa",
+    "symbol": "33LCNY-33LUSD-33WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1692519623,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5f98805a4e8be255a32880fdec7f6728c6568ba0.png",
+        "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+        "symbol": "LUSD",
+        "weight": "0.3333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7635b612792e4bfb7f2fa12a3e5d5a3f2e3c34bc.png",
+        "address": "0x7635b612792e4bfb7f2fa12a3e5d5a3f2e3c34bc",
+        "symbol": "LCNY",
+        "weight": "0.3333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.3334"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xcbfa4532d8b2ade2c261d3dd5ef2a2284f7926920000000000000000000004fa",
+    "address": "0xcbfa4532d8b2ade2c261d3dd5ef2a2284f792692",
+    "symbol": "bb-a-USDC",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1680633071,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x57d20c946a7a3812a7225b881cdcd8431d23431c",
+        "symbol": "waUSDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xcbfa4532d8b2ade2c261d3dd5ef2a2284f792692.png",
+        "address": "0xcbfa4532d8b2ade2c261d3dd5ef2a2284f792692",
+        "symbol": "bb-a-USDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x60b4601cdddc4467f31b1f770cb93c51dc7dc728000200000000000000000042",
+    "address": "0x60b4601cdddc4467f31b1f770cb93c51dc7dc728",
+    "symbol": "50PIXEL-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1623474224,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x89045d0af6a12782ec6f701ee6698beaf17d0ea2",
+        "symbol": "PIXEL",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x6667c6fa9f2b3fc1cc8d85320b62703d938e43850000000000000000000004fb",
+    "address": "0x6667c6fa9f2b3fc1cc8d85320b62703d938e4385",
+    "symbol": "bb-a-DAI",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1680633107,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x098256c06ab24f5655c5506a6488781bd711c14b",
+        "symbol": "waDAI",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6667c6fa9f2b3fc1cc8d85320b62703d938e4385.png",
+        "address": "0x6667c6fa9f2b3fc1cc8d85320b62703d938e4385",
+        "symbol": "bb-a-DAI",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x158e0fbc2271e1dcebadd365a22e2b4dd173c0db0002000000000000000005a5",
+    "address": "0x158e0fbc2271e1dcebadd365a22e2b4dd173c0db",
+    "symbol": "80IDLE-20USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1689599735,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x875773784af8135ea0ef43b5a374aad105c5d39e.png",
+        "address": "0x875773784af8135ea0ef43b5a374aad105c5d39e",
+        "symbol": "IDLE",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x51735bdfbfe3fc13dea8dc6502e2e958989429610002000000000000000000a0",
+    "address": "0x51735bdfbfe3fc13dea8dc6502e2e95898942961",
+    "symbol": "B-80UNN-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1633697910,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x226f7b842e0f0120b7e194d05432b3fd14773a9d",
+        "symbol": "UNN",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xefaa1604e82e1b3af8430b90192c1b9e8197e377000200000000000000000021",
+    "address": "0xefaa1604e82e1b3af8430b90192c1b9e8197e377",
+    "symbol": "B-50COMP-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1620159740,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png",
+        "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+        "symbol": "COMP",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x8e85e97ed19c0fa13b2549309965291fbbc0048b0000000000000000000003ba",
+    "address": "0x8e85e97ed19c0fa13b2549309965291fbbc0048b",
+    "symbol": "sfrxETH-stETH-rETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1667418911,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "address": "0x8e85e97ed19c0fa13b2549309965291fbbc0048b",
+        "symbol": "sfrxETH-stETH-rETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xac3e018457b222d93114458476f3e3416abbe38f.png",
+        "address": "0xac3e018457b222d93114458476f3e3416abbe38f",
+        "symbol": "sfrxETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png",
+        "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+        "symbol": "rETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xbd52970e2d38ce00283bbeef558e4ef0ec42725c0002000000000000000001c0",
+    "address": "0xbd52970e2d38ce00283bbeef558e4ef0ec42725c",
+    "symbol": "TRILLLBP",
+    "type": "LIQUIDITYBOOTSTRAPPING",
+    "addedTimestamp": 1650746608,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x3593da74a0adb6b3504e677b8fa40c3e77ba90ec",
+        "symbol": "TRILL",
+        "weight": "0.987472173708032256"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.012543085546096791"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x787546bf2c05e3e19e2b6bde57a203da7f682eff00020000000000000000007c",
+    "address": "0x787546bf2c05e3e19e2b6bde57a203da7f682eff",
+    "symbol": "LPePyvUSDC-29OCT21",
+    "type": "ELEMENT",
+    "addedTimestamp": 1627936276,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "address": "0xf38c3e836be9cd35072055ff6a9ba570e0b70797",
+        "symbol": "ePyvUSDC-29OCT21",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x3e87048a3bd97c8cd9ca84ed2bf6ba88495226e500020000000000000000030f",
+    "address": "0x3e87048a3bd97c8cd9ca84ed2bf6ba88495226e5",
+    "symbol": "ALBERT_LBP",
+    "type": "LIQUIDITYBOOTSTRAPPING",
+    "addedTimestamp": 1660000324,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x217afe231818ae8dbb384a95f92d252f9d26a7b0",
+        "symbol": "ALBERT",
+        "weight": "0.929152643868142185"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.070862615614475392"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x616d4d131f1147ac3b3c3cc752bab8613395b2bb000200000000000000000584",
+    "address": "0x616d4d131f1147ac3b3c3cc752bab8613395b2bb",
+    "symbol": "B-yBAL-STABLE",
+    "type": "STABLE",
+    "addedTimestamp": 1688428583,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5c6ee304399dbdb9c8ef030ab642b10820db8f56.png",
+        "address": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56",
+        "symbol": "B-80BAL-20WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "",
+        "address": "0x98e86ed5b0e48734430bfbe92101156c75418cad",
+        "symbol": "yBAL",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xd590931466cdd6d488a25da1e89dd0539723800c00020000000000000000042b",
+    "address": "0xd590931466cdd6d488a25da1e89dd0539723800c",
+    "symbol": "50RBN-50USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1673420639,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6123b0049f904d730db3c36a31167d9d4121fa6b.png",
+        "address": "0x6123b0049f904d730db3c36a31167d9d4121fa6b",
+        "symbol": "RBN",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x702605f43471183158938c1a3e5f5a359d7b31ba00020000000000000000009f",
+    "address": "0x702605f43471183158938c1a3e5f5a359d7b31ba",
+    "symbol": "B-80BAL-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1633385013,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x3ec8798b81485a254928b70cda1cf0a2bb0b74d7",
+        "symbol": "GRO",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xfb46bc8fc0d06421d362a31b7230f39462efa79a000200000000000000000332",
+    "address": "0xfb46bc8fc0d06421d362a31b7230f39462efa79a",
+    "symbol": "20OHM-80FDT",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1660746643,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png",
+        "address": "0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5",
+        "symbol": "OHM",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xed1480d12be41d92f36f5f7bdd88212e381a3677",
+        "symbol": "FDT",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x9f2b223da9f3911698c9b90ecdf3ffee37dd54a8000200000000000000000041",
+    "address": "0x9f2b223da9f3911698c9b90ecdf3ffee37dd54a8",
+    "symbol": "50YFU-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1623471179,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xa279dab6ec190ee4efce7da72896eb58ad533262",
+        "symbol": "YFU",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x23a07596cf915cccdfd5ea8ec7e0268ba548847800020000000000000000037d",
+    "address": "0x23a07596cf915cccdfd5ea8ec7e0268ba5488478",
+    "symbol": "50GUILD-50MC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1664363183,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x83e9f223e1edb3486f876ee888d76bfba26c475a",
+        "symbol": "GUILD",
+        "weight": "0.5"
+      },
+      {
+        "address": "0x949d48eca67b17269629c7194f4b727d4ef9e5d6",
+        "symbol": "MC",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x9145bcff3fb05c873b35a78e466c9e7ba1e90ef800020000000000000000048b",
+    "address": "0x9145bcff3fb05c873b35a78e466c9e7ba1e90ef8",
+    "symbol": "50ANKR-50ankrETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1676442707,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x8290333cef9e6d528dd5618fb97a76f268f3edd4",
+        "symbol": "ANKR",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe95a203b1a91a908f9b9ce46459d101078c2c3cb.png",
+        "address": "0xe95a203b1a91a908f9b9ce46459d101078c2c3cb",
+        "symbol": "ankrETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x61d5dc44849c9c87b0856a2a311536205c96c7fd000100000000000000000001",
+    "address": "0x61d5dc44849c9c87b0856a2a311536205c96c7fd",
+    "symbol": "BED",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1619037254,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
+        "symbol": "DPI",
+        "weight": "0.333333333333333333"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "symbol": "WBTC",
+        "weight": "0.333333333333333333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.333333333333333334"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x0fd5663d4893ae0d579d580584806aadd2dd0b8b000200000000000000000367",
+    "address": "0x0fd5663d4893ae0d579d580584806aadd2dd0b8b",
+    "symbol": "50rETH-50RPL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1662739812,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae78736cd615f374d3085123a210448e74fc6393.png",
+        "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+        "symbol": "rETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd33526068d116ce69f19a9ee46f0bd304f21a51f.png",
+        "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+        "symbol": "RPL",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x3e5fa9518ea95c3e533eb377c001702a9aacaa32000200000000000000000052",
+    "address": "0x3e5fa9518ea95c3e533eb377c001702a9aacaa32",
+    "symbol": "B-50WETH-50USDT",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1624393188,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+        "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        "symbol": "USDT",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x178e029173417b1f9c8bc16dcec6f697bc32374600000000000000000000025d",
+    "address": "0x178e029173417b1f9c8bc16dcec6f697bc323746",
+    "symbol": "FUD",
+    "type": "STABLE",
+    "addedTimestamp": 1655452646,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x586aa273f262909eef8fa02d90ab65f5015e0516.png",
+        "address": "0x586aa273f262909eef8fa02d90ab65f5015e0516",
+        "symbol": "FIAT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x29d7a7e0d781c957696697b94d4bc18c651e358e000200000000000000000049",
+    "address": "0x29d7a7e0d781c957696697b94d4bc18c651e358e",
+    "symbol": "PAR50-WETH50",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1623925078,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+        "symbol": "PAR",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x48607651416a943bf5ac71c41be1420538e78f87000200000000000000000327",
+    "address": "0x48607651416a943bf5ac71c41be1420538e78f87",
+    "symbol": "50Silo-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1660428400,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6f80310ca7f2c654691d1383149fa1a57d8ab1f8.png",
+        "address": "0x6f80310ca7f2c654691d1383149fa1a57d8ab1f8",
+        "symbol": "Silo",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xd689abc77b82803f22c49de5c8a0049cc74d11fd000200000000000000000524",
+    "address": "0xd689abc77b82803f22c49de5c8a0049cc74d11fd",
+    "symbol": "80USH-20unshETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1681890359,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0ae38f7e10a43b5b2fb064b42a2f4514cba909ef.png",
+        "address": "0x0ae38f7e10a43b5b2fb064b42a2f4514cba909ef",
+        "symbol": "unshETH",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe60779cc1b2c1d0580611c526a8df0e3f870ec48.png",
+        "address": "0xe60779cc1b2c1d0580611c526a8df0e3f870ec48",
+        "symbol": "USH",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x314c1a82e147489c7a65f7051e742c9d6981438e0002000000000000000003ca",
+    "address": "0x314c1a82e147489c7a65f7051e742c9d6981438e",
+    "symbol": "50USDC-50PROS",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1668463115,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.5"
+      },
+      {
+        "address": "0xbe1936a67f503e0eaf2434b0cf9f4e3d7100008a",
+        "symbol": "PROS",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x6228f64d5ba8376652bfe7e36569d595347cf6fb0002000000000000000005df",
+    "address": "0x6228f64d5ba8376652bfe7e36569d595347cf6fb",
+    "symbol": "80T-20TBTC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1693279523,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/11224/large/0x18084fba666a33d37592fa2633fd49a74dd93a88.png?1674474504",
+        "address": "0x18084fba666a33d37592fa2633fd49a74dd93a88",
+        "symbol": "tBTC",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xcdf7028ceab81fa0c6971208e83fa7872994bee5.png",
+        "address": "0xcdf7028ceab81fa0c6971208e83fa7872994bee5",
+        "symbol": "T",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x100a6a9524541e92dd068a9cd3e5def16388fec0000200000000000000000213",
+    "address": "0x100a6a9524541e92dd068a9cd3e5def16388fec0",
+    "symbol": "50COIN-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1653995717,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x06c985ff69f7257e212a89828f79497a3c8b6edf",
+        "symbol": "COIN",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x472afe4c35dc218a41736d4aceeab650db43c58400020000000000000000034f",
+    "address": "0x472afe4c35dc218a41736d4aceeab650db43c584",
+    "symbol": "80PHONON-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1661806532,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x758b4684be769e92eefea93f60dda0181ea303ec",
+        "symbol": "PHONON",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x08cc92fedc1ce2d8525176a63fcff404450f2998000200000000000000000542",
+    "address": "0x08cc92fedc1ce2d8525176a63fcff404450f2998",
+    "symbol": "50B-baoUSD-LUSD-BPT-50BAO",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1683789479,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x7e9afd25f5ec0eb24d7d4b089ae7ecb9651c8b1f",
+        "symbol": "B-baoUSD-LUSD-BPT",
+        "weight": "0.5"
+      },
+      {
+        "address": "0xce391315b414d4c7555956120461d21808a69f3a",
+        "symbol": "BAO",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x9e030b67a8384cbba09d5927533aa98010c87d9100020000000000000000008f",
+    "address": "0x9e030b67a8384cbba09d5927533aa98010c87d91",
+    "symbol": "LPeYyvUSDC-28JAN22",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1631632476,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.500000000000000001"
+      },
+      {
+        "address": "0xf1294e805b992320a3515682c6ab0fe6251067e5",
+        "symbol": "eYyvUSDC-28JAN22",
+        "weight": "0.499999999999999999"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x67b532d47a31ce1ed0800e6913dbf5f6e9c48a180002000000000000000000c5",
+    "address": "0x67b532d47a31ce1ed0800e6913dbf5f6e9c48a18",
+    "symbol": "⚗️_WEIGHTED",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1636998020,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
+        "symbol": "⚗️",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x5b1c06c4923dbba4b27cfa270ffb2e60aa28615900020000000000000000004a",
+    "address": "0x5b1c06c4923dbba4b27cfa270ffb2e60aa286159",
+    "symbol": "PAR75-MIMO25",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1623925198,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+        "symbol": "PAR",
+        "weight": "0.75"
+      },
+      {
+        "address": "0x90b831fa3bebf58e9744a14d638e25b4ee06f9bc",
+        "symbol": "MIMO",
+        "weight": "0.25"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x844ba71d4902ed3de091112951b9c4b4d25a09dd00020000000000000000014b",
+    "address": "0x844ba71d4902ed3de091112951b9c4b4d25a09dd",
+    "symbol": "Balancer 90 EEFI 10 WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1644875098,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x92915c346287ddfbcec8f86c8eb52280ed05b3a3",
+        "symbol": "EEFI",
+        "weight": "0.9"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.1"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x0a8156fdc4b488cb1bf1c44c7ee944088174fa30000200000000000000000319",
+    "address": "0x0a8156fdc4b488cb1bf1c44c7ee944088174fa30",
+    "symbol": "80MYC-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1660190953,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x4b13006980acb09645131b91d259eaa111eaf5ba",
+        "symbol": "MYC",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x793f2d5cd52dfafe7a1a1b0b3988940ba2d6a63d0000000000000000000004f8",
+    "address": "0x793f2d5cd52dfafe7a1a1b0b3988940ba2d6a63d",
+    "symbol": "B-vETH-STABLE",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1680627563,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4bc3263eb5bb2ef7ad9ab6fb68be80e43b43801f.png",
+        "address": "0x4bc3263eb5bb2ef7ad9ab6fb68be80e43b43801f",
+        "symbol": "vETH",
+        "weight": null
+      },
+      {
+        "address": "0x793f2d5cd52dfafe7a1a1b0b3988940ba2d6a63d",
+        "symbol": "B-vETH-STABLE",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x4db9024fc9f477134e00da0da3c77de98d9836ac000200000000000000000086",
+    "address": "0x4db9024fc9f477134e00da0da3c77de98d9836ac",
+    "symbol": "LPePyvWBTC-26NOV21",
+    "type": "ELEMENT",
+    "addedTimestamp": 1630433657,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "symbol": "WBTC",
+        "weight": null
+      },
+      {
+        "address": "0x6bf924137e769c0a5c443dce6ec885552d31d579",
+        "symbol": "ePyvWBTC-26NOV21",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x494b26d4aee801cb1fabf498ee24f0af20238743000200000000000000000083",
+    "address": "0x494b26d4aee801cb1fabf498ee24f0af20238743",
+    "symbol": "FOURWP",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1629791999,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
+        "symbol": "FOUR",
+        "weight": "0.7"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.3"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xe2469f47ab58cf9cf59f9822e3c5de4950a41c49000200000000000000000089",
+    "address": "0xe2469f47ab58cf9cf59f9822e3c5de4950a41c49",
+    "symbol": "mBPT",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1631266727,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
+        "symbol": "MTA",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x988f2b03aea264378518b7235d08c6cb2583aaa40001000000000000000004b5",
+    "address": "0x988f2b03aea264378518b7235d08c6cb2583aaa4",
+    "symbol": "29WBTC-4wstETH-67TRAC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1677727607,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "symbol": "WBTC",
+        "weight": "0.29"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": "0.0433"
+      },
+      {
+        "address": "0xaa7a9ca87d3694b5755f213b5d04094b8d0f0a6f",
+        "symbol": "TRAC",
+        "weight": "0.6667"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x2291627599a7441d53c4645d7b12720026c336180002000000000000000002a5",
+    "address": "0x2291627599a7441d53c4645d7b12720026c33618",
+    "symbol": "PRT_LBP",
+    "type": "LIQUIDITYBOOTSTRAPPING",
+    "addedTimestamp": 1657473671,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.14000152590218967"
+      },
+      {
+        "address": "0xc318c2d897283852f6f20ebead6b605907d911fd",
+        "symbol": "PRT",
+        "weight": "0.860013733119707027"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xf3a605da753e9de545841de10ea8bffbd1da9c75000200000000000000000035",
+    "address": "0xf3a605da753e9de545841de10ea8bffbd1da9c75",
+    "symbol": "sdveCRV90-CRV10",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1622555239,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x478bbc744811ee8310b461514bdc29d03739084d",
+        "symbol": "sdveCRV-DAO",
+        "weight": "0.9"
+      },
+      {
+        "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+        "symbol": "CRV",
+        "weight": "0.1"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x5f7fa48d765053f8dd85e052843e12d23e3d7bc50002000000000000000000c0",
+    "address": "0x5f7fa48d765053f8dd85e052843e12d23e3d7bc5",
+    "symbol": "NWWP",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1636686679,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xcfeaead4947f0705a14ec42ac3d44129e1ef3ed5.png",
+        "address": "0xcfeaead4947f0705a14ec42ac3d44129e1ef3ed5",
+        "symbol": "NOTE",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x20facecaa68e9b7c92d2d0ec9136d864df805233000100000000000000000190",
+    "address": "0x20facecaa68e9b7c92d2d0ec9136d864df805233",
+    "symbol": "WILDFIRE",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1649274546,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9/logo.png",
+        "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+        "symbol": "AAVE",
+        "weight": "0.125"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba100000625a3754423978a60c9317c58a424e3d.png",
+        "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+        "symbol": "BAL",
+        "weight": "0.125"
+      },
+      {
+        "address": "0xba5bde662c17e2adff1075610382b9b691296350",
+        "symbol": "RARE",
+        "weight": "0.125"
+      },
+      {
+        "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+        "symbol": "ENS",
+        "weight": "0.125"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd33526068d116ce69f19a9ee46f0bd304f21a51f.png",
+        "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+        "symbol": "RPL",
+        "weight": "0.125"
+      },
+      {
+        "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+        "symbol": "GTC",
+        "weight": "0.125"
+      },
+      {
+        "address": "0xf2051511b9b121394fa75b8f7d4e7424337af687",
+        "symbol": "HAUS",
+        "weight": "0.125"
+      },
+      {
+        "address": "0xfb5453340c03db5ade474b27e68b6a9c6b2823eb",
+        "symbol": "ROBOT",
+        "weight": "0.125"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xc2b021133d1b0cf07dba696fd5dd89338428225b000000000000000000000598",
+    "address": "0xc2b021133d1b0cf07dba696fd5dd89338428225b",
+    "symbol": "GHO/bb-a-USD",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689432443,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/30663/large/ghoaave.jpeg?1686151372",
+        "address": "0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f",
+        "symbol": "GHO",
+        "weight": null
+      },
+      {
+        "address": "0xc2b021133d1b0cf07dba696fd5dd89338428225b",
+        "symbol": "GHO/bb-a-USD",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/25769/large/0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2.png?1653604699",
+        "address": "0xc443c15033fcb6cf72cc24f1bda0db070ddd9786",
+        "symbol": "bb-a-USD",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xe0fcbf4d98f0ad982db260f86cf28b49845403c5000000000000000000000504",
+    "address": "0xe0fcbf4d98f0ad982db260f86cf28b49845403c5",
+    "symbol": "wstETH-bb-a-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1680692387,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x60d604890feaa0b5460b28a424407c24fe89374a.png",
+        "address": "0x60d604890feaa0b5460b28a424407c24fe89374a",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0.png",
+        "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "address": "0xe0fcbf4d98f0ad982db260f86cf28b49845403c5",
+        "symbol": "wstETH-bb-a-WETH-BPT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xec60a5fef79a92c741cb74fdd6bfc340c0279b01000200000000000000000015",
+    "address": "0xec60a5fef79a92c741cb74fdd6bfc340c0279b01",
+    "symbol": "B-50REN-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1620154724,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x408e41876cccdc0f92210600ef50372656052a38",
+        "symbol": "REN",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x7c9cf12d783821d5c63d8e9427af5c44bad924450002000000000000000000b4",
+    "address": "0x7c9cf12d783821d5c63d8e9427af5c44bad92445",
+    "symbol": "LPeYyvUSDC-17DEC21",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1635864294,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x33dde19c163cdcce4e5a81f04a2af561b9ef58d7",
+        "symbol": "eYyvUSDC-17DEC21",
+        "weight": "0.499999999999999999"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.500000000000000001"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x6dec8d0496590521c8f4f1dee7cfe9c7a6b7a4800002000000000000000001d5",
+    "address": "0x6dec8d0496590521c8f4f1dee7cfe9c7a6b7a480",
+    "symbol": "First Order Token Copper LBP",
+    "type": "LIQUIDITYBOOTSTRAPPING",
+    "addedTimestamp": 1651081490,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x57b5920a4c057c6206589b03656f933e24e97f1c",
+        "symbol": "FORCE",
+        "weight": "0.500007629510948349"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "weight": "0.500007629510948349"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x2b218683178d029bab6c9789b1073aa6c96e517600000000000000000000058c",
+    "address": "0x2b218683178d029bab6c9789b1073aa6c96e5176",
+    "symbol": "bb-s-DAI",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1689165887,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/31367/large/bb-s-dai.png?1692693634",
+        "address": "0x2b218683178d029bab6c9789b1073aa6c96e5176",
+        "symbol": "bb-s-DAI",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x83f20f44975d03b1b09e64809b757c47f942beea.png",
+        "address": "0x83f20f44975d03b1b09e64809b757c47f942beea",
+        "symbol": "sDAI",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x2d344a84bac123660b021eebe4eb6f12ba25fe8600020000000000000000018a",
+    "address": "0x2d344a84bac123660b021eebe4eb6f12ba25fe86",
+    "symbol": "20WETH-80FDT",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1649198464,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xed1480d12be41d92f36f5f7bdd88212e381a3677",
+        "symbol": "FDT",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xd4e2af4507b6b89333441c0c398edffb40f86f4d0001000000000000000002ab",
+    "address": "0xd4e2af4507b6b89333441c0c398edffb40f86f4d",
+    "symbol": "33WBTC-33WETH-33WAMPL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1657674579,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "symbol": "WBTC",
+        "weight": "0.3333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.3333"
+      },
+      {
+        "address": "0xedb171c18ce90b633db442f2a6f72874093b49ef",
+        "symbol": "WAMPL",
+        "weight": "0.3334"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xc45d42f801105e861e86658648e3678ad7aa70f900010000000000000000011e",
+    "address": "0xc45d42f801105e861e86658648e3678ad7aa70f9",
+    "symbol": "50OHM-25DAI-25WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1641174593,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5.png",
+        "address": "0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5",
+        "symbol": "OHM",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.25"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0x9f2a5e84abf5aa0771f4027c726b5697d9d2010a000200000000000000000342",
+    "address": "0x9f2a5e84abf5aa0771f4027c726b5697d9d2010a",
+    "symbol": "50WBTC-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1661139419,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "symbol": "WBTC",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.png",
+        "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "MAINNET",
+    "id": "0xedf085f65b4f6c155e13155502ef925c9a756003000200000000000000000123",
+    "address": "0xedf085f65b4f6c155e13155502ef925c9a756003",
+    "symbol": "LPePyvDAI-29APR22",
+    "type": "ELEMENT",
+    "addedTimestamp": 1641340147,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x2c72692e94e757679289ac85d3556b2c0f717e0e",
+        "symbol": "ePyvDAI-29APR22",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x216690738aac4aa0c4770253ca26a28f0115c595000000000000000000000b2c",
+    "address": "0x216690738aac4aa0c4770253ca26a28f0115c595",
+    "symbol": "stMATIC-bb-a-WMATIC-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1680716074,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x216690738aac4aa0c4770253ca26a28f0115c595",
+        "symbol": "stMATIC-bb-a-WMATIC-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png",
+        "address": "0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4",
+        "symbol": "stMATIC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe4885ed2818cc9e840a25f94f9b2a28169d1aea7.png",
+        "address": "0xe4885ed2818cc9e840a25f94f9b2a28169d1aea7",
+        "symbol": "bb-a-WMATIC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xe4885ed2818cc9e840a25f94f9b2a28169d1aea7000000000000000000000b29",
+    "address": "0xe4885ed2818cc9e840a25f94f9b2a28169d1aea7",
+    "symbol": "bb-a-WMATIC",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1680692938,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": null
+      },
+      {
+        "address": "0x0d6135b2cfbae3b1c58368a93b855fa54fa5aae1",
+        "symbol": "waWMATIC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe4885ed2818cc9e840a25f94f9b2a28169d1aea7.png",
+        "address": "0xe4885ed2818cc9e840a25f94f9b2a28169d1aea7",
+        "symbol": "bb-a-WMATIC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xf0ad209e2e969eaaa8c882aac71f02d8a047d5c2000200000000000000000b49",
+    "address": "0xf0ad209e2e969eaaa8c882aac71f02d8a047d5c2",
+    "symbol": "ECLP-WMATIC-stMATIC",
+    "type": "GYROE",
+    "addedTimestamp": 1681964404,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png",
+        "address": "0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4",
+        "symbol": "stMATIC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xae8f935830f6b418804836eacb0243447b6d977c000200000000000000000ad1",
+    "address": "0xae8f935830f6b418804836eacb0243447b6d977c",
+    "symbol": "20USDC-80GHST",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1678388943,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x385eeac5cb85a38a9a07a70c73e0a3271cfb54a7",
+        "symbol": "GHST",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xb797adfb7b268faeaa90cadbfed464c76ee599cd0002000000000000000005ba",
+    "address": "0xb797adfb7b268faeaa90cadbfed464c76ee599cd",
+    "symbol": "tetuBAL-BALWETH",
+    "type": "STABLE",
+    "addedTimestamp": 1655487934,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f.png",
+        "address": "0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f",
+        "symbol": "20WETH-80BAL",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x7fc9e0aa043787bfad28e29632ada302c790ce33.png",
+        "address": "0x7fc9e0aa043787bfad28e29632ada302c790ce33",
+        "symbol": "tetuBAL",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xcd78a20c597e367a4e478a2411ceb790604d7c8f000000000000000000000c22",
+    "address": "0xcd78a20c597e367a4e478a2411ceb790604d7c8f",
+    "symbol": "maticX-WMATIC-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692115347,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": null
+      },
+      {
+        "address": "0xcd78a20c597e367a4e478a2411ceb790604d7c8f",
+        "symbol": "maticX-WMATIC-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfa68fb4628dff1028cfec22b4162fccd0d45efb6.png",
+        "address": "0xfa68fb4628dff1028cfec22b4162fccd0d45efb6",
+        "symbol": "MaticX",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xe2f706ef1f7240b803aae877c9c762644bb808d80002000000000000000008c2",
+    "address": "0xe2f706ef1f7240b803aae877c9c762644bb808d8",
+    "symbol": "80TETU-20USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1668073610,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x255707b70bf90aa112006e1b07b9aea6de021424.png",
+        "address": "0x255707b70bf90aa112006e1b07b9aea6de021424",
+        "symbol": "TETU",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x8159462d255c1d24915cb51ec361f700174cd99400000000000000000000075d",
+    "address": "0x8159462d255c1d24915cb51ec361f700174cd994",
+    "symbol": "B-stMATIC-Stable",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1662566113,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png",
+        "address": "0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4",
+        "symbol": "stMATIC",
+        "weight": null
+      },
+      {
+        "address": "0x8159462d255c1d24915cb51ec361f700174cd994",
+        "symbol": "B-stMATIC-Stable",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xe78b25c06db117fdf8f98583cdaaa6c92b79e917000000000000000000000b2b",
+    "address": "0xe78b25c06db117fdf8f98583cdaaa6c92b79e917",
+    "symbol": "MaticX-bb-a-WMATIC-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1680713507,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe4885ed2818cc9e840a25f94f9b2a28169d1aea7.png",
+        "address": "0xe4885ed2818cc9e840a25f94f9b2a28169d1aea7",
+        "symbol": "bb-a-WMATIC",
+        "weight": null
+      },
+      {
+        "address": "0xe78b25c06db117fdf8f98583cdaaa6c92b79e917",
+        "symbol": "MaticX-bb-a-WMATIC-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfa68fb4628dff1028cfec22b4162fccd0d45efb6.png",
+        "address": "0xfa68fb4628dff1028cfec22b4162fccd0d45efb6",
+        "symbol": "MaticX",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x726e324c29a1e49309672b244bdc4ff62a270407000200000000000000000702",
+    "address": "0x726e324c29a1e49309672b244bdc4ff62a270407",
+    "symbol": "BPT",
+    "type": "FX",
+    "addedTimestamp": 1660876171,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xdc3326e71d45186f113a2f448984ca0e8d201995.png",
+        "address": "0xdc3326e71d45186f113a2f448984ca0e8d201995",
+        "symbol": "XSGD",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x03cd191f589d12b0582a99808cf19851e468e6b500010000000000000000000a",
+    "address": "0x03cd191f589d12b0582a99808cf19851e468e6b5",
+    "symbol": "BPTC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1625175772,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6",
+        "symbol": "WBTC",
+        "weight": "0.333333333333333333"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.333333333333333333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.333333333333333334"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x0297e37f1873d2dab4487aa67cd56b58e2f27875000100000000000000000002",
+    "address": "0x0297e37f1873d2dab4487aa67cd56b58e2f27875",
+    "symbol": "B-POLYBASE",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1624480165,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.25"
+      },
+      {
+        "address": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+        "symbol": "BAL",
+        "weight": "0.25"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x02d2e2d7a89d6c5cb3681cfcb6f7dac02a55eda400000000000000000000088f",
+    "address": "0x02d2e2d7a89d6c5cb3681cfcb6f7dac02a55eda4",
+    "symbol": "B-csMATIC-Stable",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1667478958,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x02d2e2d7a89d6c5cb3681cfcb6f7dac02a55eda4",
+        "symbol": "B-csMATIC-Stable",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": null
+      },
+      {
+        "address": "0xfcbb00df1d663eee58123946a30ab2138bf9eb2a",
+        "symbol": "csMATIC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x8f9dd2064eb38e8e40f2ab67bde27c0e16ea9b080002000000000000000004ca",
+    "address": "0x8f9dd2064eb38e8e40f2ab67bde27c0e16ea9b08",
+    "symbol": "50RBW-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1651065950,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x431cd3c9ac9fc73644bf68bf5691f4b83f9e104f",
+        "symbol": "RBW",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x513cdee00251f39de280d9e5f771a6eafebcc88e000000000000000000000a6b",
+    "address": "0x513cdee00251f39de280d9e5f771a6eafebcc88e",
+    "symbol": "2eur (PAR)",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1676243596,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4e3decbb3645551b8a19f0ea1678079fcb33fb4c.png",
+        "address": "0x4e3decbb3645551b8a19f0ea1678079fcb33fb4c",
+        "symbol": "jEUR",
+        "weight": null
+      },
+      {
+        "address": "0x513cdee00251f39de280d9e5f771a6eafebcc88e",
+        "symbol": "2eur (PAR)",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/14153/large/par_round_200.png?1614670422",
+        "address": "0xe2aa7db6da1dae97c5f5c6914d285fbfcc32a128",
+        "symbol": "PAR",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xee278d943584dd8640eaf4cc6c7a5c80c0073e85000200000000000000000bc7",
+    "address": "0xee278d943584dd8640eaf4cc6c7a5c80c0073e85",
+    "symbol": "ECLP-WMATIC-MATICX",
+    "type": "GYROE",
+    "addedTimestamp": 1688667140,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfa68fb4628dff1028cfec22b4162fccd0d45efb6.png",
+        "address": "0xfa68fb4628dff1028cfec22b4162fccd0d45efb6",
+        "symbol": "MaticX",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xf3312968c7d768c19107731100ece7d4780b47b2000200000000000000000a50",
+    "address": "0xf3312968c7d768c19107731100ece7d4780b47b2",
+    "symbol": "20WMATIC-80SPHERE",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1675709065,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x62f594339830b90ae4c084ae7d223ffafd9658a7.png",
+        "address": "0x62f594339830b90ae4c084ae7d223ffafd9658a7",
+        "symbol": "SPHERE",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xb204bf10bc3a5435017d3db247f56da601dfe08a0002000000000000000000fe",
+    "address": "0xb204bf10bc3a5435017d3db247f56da601dfe08a",
+    "symbol": "20USDC-80THX",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1638798765,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x2934b36ca9a4b31e633c5be670c8c8b28b6aa015.png",
+        "address": "0x2934b36ca9a4b31e633c5be670c8c8b28b6aa015",
+        "symbol": "THX",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x129988450c7cd622ec251ff0ea1e8a034c42d36c00020000000000000000074c",
+    "address": "0x129988450c7cd622ec251ff0ea1e8a034c42d36c",
+    "symbol": "20USDC-80FITT",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1662121825,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x656bf6767fa8863ac0dd0b7d2a26602b838a2e70",
+        "symbol": "FITT",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xaaf737aeb1e5f1dc9429de4a639fe16c42fa1fe3000200000000000000000bf9",
+    "address": "0xaaf737aeb1e5f1dc9429de4a639fe16c42fa1fe3",
+    "symbol": "50fireEP-50FBX",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1689670696,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xa2b205f8c0f0e30b3f73b7716a718c53cb8e5cc3",
+        "symbol": "fireEP",
+        "weight": "0.5"
+      },
+      {
+        "address": "0xd125443f38a69d776177c2b9c041f462936f8218",
+        "symbol": "FBX",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xb53f4e2f1e7a1b8b9d09d2f2739ac6753f5ba5cb000200000000000000000137",
+    "address": "0xb53f4e2f1e7a1b8b9d09d2f2739ac6753f5ba5cb",
+    "symbol": "80HDAO-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1639068735,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x72928d5436ff65e57f72d5566dcd3baedc649a88",
+        "symbol": "HDAO",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x2dbc9ab0160087ae59474fb7bed95b9e808fa6bc0001000000000000000003db",
+    "address": "0x2dbc9ab0160087ae59474fb7bed95b9e808fa6bc",
+    "symbol": "20USDC-40TEL-40DFX",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1647629491,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.4"
+      },
+      {
+        "address": "0xe7804d91dfcde7f776c90043e03eaa6df87e6395",
+        "symbol": "DFX",
+        "weight": "0.4"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x625bfdd5052c27c45c8482efb26990af66aea94a000100000000000000000a90",
+    "address": "0x625bfdd5052c27c45c8482efb26990af66aea94a",
+    "symbol": "15WMATIC-15USDC-70MASQ",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1677628886,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": "0.15"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.15"
+      },
+      {
+        "address": "0xee9a352f6aac4af1a5b9f467f6a93e0ffbe9dd35",
+        "symbol": "MASQ",
+        "weight": "0.7"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x65fe9314be50890fb01457be076fafd05ff32b9a000000000000000000000a96",
+    "address": "0x65fe9314be50890fb01457be076fafd05ff32b9a",
+    "symbol": "B-stETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1677786502,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd.png",
+        "address": "0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "address": "0x65fe9314be50890fb01457be076fafd05ff32b9a",
+        "symbol": "B-stETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000034",
+    "address": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56",
+    "symbol": "TELX-80TEL-20USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1627537122,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000012",
+    "address": "0x06df3b2bbb68adc8b0e302443692037ed9f91b42",
+    "symbol": "BPSP",
+    "type": "STABLE",
+    "addedTimestamp": 1625240232,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "address": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
+        "symbol": "DAI",
+        "weight": null
+      },
+      {
+        "address": "0xa3fa99a148fa48d14ed51d610c367c61876997f1",
+        "symbol": "miMATIC",
+        "weight": null
+      },
+      {
+        "address": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+        "symbol": "USDT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xb20fc01d21a50d2c734c4a1262b4404d41fa7bf000000000000000000000075c",
+    "address": "0xb20fc01d21a50d2c734c4a1262b4404d41fa7bf0",
+    "symbol": " B-MaticX-Stable",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1662565927,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": null
+      },
+      {
+        "address": "0xb20fc01d21a50d2c734c4a1262b4404d41fa7bf0",
+        "symbol": " B-MaticX-Stable",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfa68fb4628dff1028cfec22b4162fccd0d45efb6.png",
+        "address": "0xfa68fb4628dff1028cfec22b4162fccd0d45efb6",
+        "symbol": "MaticX",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x805ca3ccc61cc231851dee2da6aabff0a7714aa7000200000000000000000361",
+    "address": "0x805ca3ccc61cc231851dee2da6aabff0a7714aa7",
+    "symbol": "BAL-VISION-LP",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1646249777,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x034b2090b579228482520c589dbd397c53fc51cc",
+        "symbol": "VISION",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x36128d5436d2d70cab39c9af9cce146c38554ff0000100000000000000000008",
+    "address": "0x36128d5436d2d70cab39c9af9cce146c38554ff0",
+    "symbol": "B-POLYDEFI",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1624551483,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
+        "symbol": "LINK",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+        "symbol": "BAL",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xd6df932a45c0f255f85145f286ea0b292b21c90b",
+        "symbol": "AAVE",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x9841438683c2efbfb28c94ec341544b94e4f6dd5000100000000000000000b8f",
+    "address": "0x9841438683c2efbfb28c94ec341544b94e4f6dd5",
+    "symbol": "25WBTC-25USDC-25PAXG-25WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1684989160,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6",
+        "symbol": "WBTC",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.25"
+      },
+      {
+        "address": "0x553d3d295e0f695b9228246232edf400ed3560b5",
+        "symbol": "PAXG",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.25"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xf099b7c3bd5a221aa34cb83004a50d66b0189ad0000100000000000000000036",
+    "address": "0xf099b7c3bd5a221aa34cb83004a50d66b0189ad0",
+    "symbol": "TELX-60TEL-20WBTC-20USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1627538490,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6",
+        "symbol": "WBTC",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.6"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x577f6076e558818a5df21ce4acde9a9623ec0b4c000200000000000000000a64",
+    "address": "0x577f6076e558818a5df21ce4acde9a9623ec0b4c",
+    "symbol": "80SD-20maticX",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1676147094,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x1d734a02ef1e1f5886e66b0673b71af5b53ffa94.png",
+        "address": "0x1d734a02ef1e1f5886e66b0673b71af5b53ffa94",
+        "symbol": "SD",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfa68fb4628dff1028cfec22b4162fccd0d45efb6.png",
+        "address": "0xfa68fb4628dff1028cfec22b4162fccd0d45efb6",
+        "symbol": "MaticX",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xdb1db6e248d7bb4175f6e5a382d0a03fe3dcc813000100000000000000000035",
+    "address": "0xdb1db6e248d7bb4175f6e5a382d0a03fe3dcc813",
+    "symbol": "TELX-60TEL-20BAL-20USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1627537692,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+        "symbol": "BAL",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.6"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x0a2b8a82ffdf39acce59729f6285baf530a13c5300020000000000000000047d",
+    "address": "0x0a2b8a82ffdf39acce59729f6285baf530a13c53",
+    "symbol": "20GRT-80TEL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1649719474,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x5fe2b58c013d7601147dcdd68c143a77499f5531",
+        "symbol": "GRT",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x186084ff790c65088ba694df11758fae4943ee9e000200000000000000000032",
+    "address": "0x186084ff790c65088ba694df11758fae4943ee9e",
+    "symbol": "TELX-50TEL-50BAL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1627530378,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+        "symbol": "BAL",
+        "weight": "0.5"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f000200000000000000000426",
+    "address": "0x3d468ab2329f296e1b9d8476bb54dd77d8c2320f",
+    "symbol": "20WETH-80BAL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1648637234,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+        "symbol": "BAL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xe93a1e6fb57d2e2be40377841a6477cfe1ef55c2000100000000000000000bbb",
+    "address": "0xe93a1e6fb57d2e2be40377841a6477cfe1ef55c2",
+    "symbol": "35AGA-20wstETH-3USDC-8stMATIC-35AGAr",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1687909713,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x033d942a6b495c4071083f4cde1f17e986fe856c",
+        "symbol": "AGA",
+        "weight": "0.35"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd.png",
+        "address": "0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd",
+        "symbol": "wstETH",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.025"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png",
+        "address": "0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4",
+        "symbol": "stMATIC",
+        "weight": "0.075"
+      },
+      {
+        "address": "0xf84bd51eab957c2e7b7d646a3427c5a50848281d",
+        "symbol": "AGAr",
+        "weight": "0.35"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xd5d7bc115b32ad1449c6d0083e43c87be95f2809000100000000000000000033",
+    "address": "0xd5d7bc115b32ad1449c6d0083e43c87be95f2809",
+    "symbol": "TELX-60TEL-20WETH-20USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1627534052,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.6"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xfa73e062497b0cbd5012385a08d9616ca5bd9ee900020000000000000000047b",
+    "address": "0xfa73e062497b0cbd5012385a08d9616ca5bd9ee9",
+    "symbol": "20CRV-80TEL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1649718714,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x172370d5cd63279efa6d502dab29171933a610af",
+        "symbol": "CRV",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081",
+    "address": "0x8a8fcd351ed553fc75aecbc566a32f94471f302e",
+    "symbol": "pSeed",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1636863878,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x00e5646f60ac6fb446f621d146b6e1886f002905",
+        "symbol": "RAI",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xeaecc18198a475c921b24b8a6c1c1f0f5f3f7ea0",
+        "symbol": "SEED",
+        "weight": "0.6"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xdac42eeb17758daa38caf9a3540c808247527ae3000200000000000000000a2b",
+    "address": "0xdac42eeb17758daa38caf9a3540c808247527ae3",
+    "symbol": "2CLP-USDC-DAI",
+    "type": "GYRO2",
+    "addedTimestamp": 1674129549,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "address": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
+        "symbol": "DAI",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xcf354603a9aebd2ff9f33e1b04246d8ea204ae9500020000000000000000005a",
+    "address": "0xcf354603a9aebd2ff9f33e1b04246d8ea204ae95",
+    "symbol": "B-50WBTC-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1632845173,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6",
+        "symbol": "WBTC",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x82db37683832a36f1b5c2863d7f9c4438ded4093000200000000000000000477",
+    "address": "0x82db37683832a36f1b5c2863d7f9c4438ded4093",
+    "symbol": "20LINK-80TEL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1649716132,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
+        "symbol": "LINK",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xffbb77fb2725b5c227dd2879d813587a30c5359c000200000000000000000659",
+    "address": "0xffbb77fb2725b5c227dd2879d813587a30c5359c",
+    "symbol": "20SOL-80TEL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1658326895,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x7dff46370e9ea5f0bad3c4e29711ad50062ea7a4",
+        "symbol": "SOL",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xd208168d2a512240eb82582205d94a0710bce4e7000100000000000000000038",
+    "address": "0xd208168d2a512240eb82582205d94a0710bce4e7",
+    "symbol": "TELX-60TEL-20WMATIC-20USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1627539776,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.6"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x385fd3414afb52d5cd60e22f17826cf9920602440002000000000000000004e0",
+    "address": "0x385fd3414afb52d5cd60e22f17826cf992060244",
+    "symbol": "20APE-80TEL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1651602056,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xb7b31a6bc18e48888545ce79e83e06003be70930",
+        "symbol": "APE",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xeab6455f8a99390b941a33bbdaf615abdf93455e000200000000000000000a66",
+    "address": "0xeab6455f8a99390b941a33bbdaf615abdf93455e",
+    "symbol": "50THX-50stMATIC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1676148532,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer-labs/assets/refactor-for-multichain/assets/0x2934b36ca9a4b31e633c5be670c8c8b28b6aa015.png",
+        "address": "0x2934b36ca9a4b31e633c5be670c8c8b28b6aa015",
+        "symbol": "THX",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png",
+        "address": "0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4",
+        "symbol": "stMATIC",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xc42c42256b484e574a458d5d8ee4fd7876f6d8d700020000000000000000047e",
+    "address": "0xc42c42256b484e574a458d5d8ee4fd7876f6d8d7",
+    "symbol": "20MKR-80TEL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1649719942,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x6f7c932e7684666c9fd1d44527765433e01ff61d",
+        "symbol": "MKR",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x77215a7e8a8d427d25660414788d2c58dd56898900020000000000000000047c",
+    "address": "0x77215a7e8a8d427d25660414788d2c58dd568989",
+    "symbol": "20UNI-80TEL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1649718996,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xb33eaad8d922b1083446dc23f610c2567fb5180f",
+        "symbol": "UNI",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x39cd55ff7e7d7c66d7d2736f1d5d4791cdab895b000100000000000000000037",
+    "address": "0x39cd55ff7e7d7c66d7d2736f1d5d4791cdab895b",
+    "symbol": "TELX-60TEL-20AAVE-20USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1627539360,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xd6df932a45c0f255f85145f286ea0b292b21c90b",
+        "symbol": "AAVE",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.6"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x42942cdec85078cf0e28e9cb5acd40cb53997ed6000000000000000000000bea",
+    "address": "0x42942cdec85078cf0e28e9cb5acd40cb53997ed6",
+    "symbol": "2BRL (BRZ)",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689338930,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "",
+        "address": "0x42942cdec85078cf0e28e9cb5acd40cb53997ed6",
+        "symbol": "2BRL (BRZ)",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/8472/large/MicrosoftTeams-image_%286%29.png?1674480131",
+        "address": "0x4ed141110f6eeeaba9a1df36d8c26f684d2475dc",
+        "symbol": "BRZ",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf2f77fe7b8e66571e0fca7104c4d670bf1c8d722.png",
+        "address": "0xf2f77fe7b8e66571e0fca7104c4d670bf1c8d722",
+        "symbol": "jBRL",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xce66904b68f1f070332cbc631de7ee98b650b499000100000000000000000009",
+    "address": "0xce66904b68f1f070332cbc631de7ee98b650b499",
+    "symbol": "B-POLYDEFI",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1624551793,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
+        "symbol": "LINK",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.25"
+      },
+      {
+        "address": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+        "symbol": "BAL",
+        "weight": "0.25"
+      },
+      {
+        "address": "0xd6df932a45c0f255f85145f286ea0b292b21c90b",
+        "symbol": "AAVE",
+        "weight": "0.25"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x6ff633d7eaafe1f6e4c6f0280317b93125aaa7eb00020000000000000000065a",
+    "address": "0x6ff633d7eaafe1f6e4c6f0280317b93125aaa7eb",
+    "symbol": "20SAND-80TEL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1658327247,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xbbba073c31bf03b8acf7c28ef0738decf3695683",
+        "symbol": "SAND",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x4e7f40cd37cee710f5e87ad72959d30ef8a01a5d00010000000000000000000b",
+    "address": "0x4e7f40cd37cee710f5e87ad72959d30ef8a01a5d",
+    "symbol": "BPSG",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1625178126,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.25"
+      },
+      {
+        "address": "0x50b728d8d964fd00c2d0aad81718b71311fef68a",
+        "symbol": "SNX",
+        "weight": "0.25"
+      },
+      {
+        "address": "0x5fe2b58c013d7601147dcdd68c143a77499f5531",
+        "symbol": "GRT",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.25"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xfe9815f3db73234bc804fea94044299b33afe6ff0002000000000000000007a3",
+    "address": "0xfe9815f3db73234bc804fea94044299b33afe6ff",
+    "symbol": "JRTETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1664135838,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x596ebe76e2db4470966ea395b0d063ac6197a8c5",
+        "symbol": "JRT",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x7c9cf12d783821d5c63d8e9427af5c44bad92445000100000000000000000051",
+    "address": "0x7c9cf12d783821d5c63d8e9427af5c44bad92445",
+    "symbol": "B-33AVAX-33WETH-33SOL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1631563951,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x2c89bbc92bd86f8075d1decc58c7f4e0107f286b",
+        "symbol": "AVAX",
+        "weight": "0.333333333333333333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.333333333333333333"
+      },
+      {
+        "address": "0x7dff46370e9ea5f0bad3c4e29711ad50062ea7a4",
+        "symbol": "SOL",
+        "weight": "0.333333333333333334"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x975b4bb277244af48493cdaf70b096bbdb95411d000200000000000000000784",
+    "address": "0x975b4bb277244af48493cdaf70b096bbdb95411d",
+    "symbol": "20USDC-80UNIM",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1663265268,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x64060ab139feaae7f06ca4e63189d86adeb51691",
+        "symbol": "UNIM",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x10f21c9bd8128a29aa785ab2de0d044dcdd79436000200000000000000000059",
+    "address": "0x10f21c9bd8128a29aa785ab2de0d044dcdd79436",
+    "symbol": "B-50WETH-50USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1632845033,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xa2c0539cf5a8a930215d82106d8973a2031f7fb300020000000000000000047a",
+    "address": "0xa2c0539cf5a8a930215d82106d8973a2031f7fb3",
+    "symbol": "20MANA-80TEL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1649718340,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xa1c57f48f0deb89f569dfbe6e2b7f46d33606fd4",
+        "symbol": "MANA",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x913b9ae6d6a228a38fbf2310e176c6ea82e57611000200000000000000000487",
+    "address": "0x913b9ae6d6a228a38fbf2310e176c6ea82e57611",
+    "symbol": "20AXS-80TEL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1649882136,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x61bdd9c7d4df4bf47a4508c0c8245505f2af5b7b",
+        "symbol": "AXS",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x17f1ef81707811ea15d9ee7c741179bbe2a63887000100000000000000000799",
+    "address": "0x17f1ef81707811ea15d9ee7c741179bbe2a63887",
+    "symbol": "3CLP-BUSD-USDC-USDT",
+    "type": "GYRO3",
+    "addedTimestamp": 1663685426,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "address": "0x9c9e5fd8bbc25984b178fdce6117defa39d2db39",
+        "symbol": "BUSD",
+        "weight": null
+      },
+      {
+        "address": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+        "symbol": "USDT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xfa9ee04a5545d8e0a26b30f5ca5cbecd75ea645f000200000000000000000798",
+    "address": "0xfa9ee04a5545d8e0a26b30f5ca5cbecd75ea645f",
+    "symbol": "2CLP-WBTC-WETH",
+    "type": "GYRO2",
+    "addedTimestamp": 1663683164,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6",
+        "symbol": "WBTC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x74c7a222fb745628760b01ca99f51f9473377b95000200000000000000000c08",
+    "address": "0x74c7a222fb745628760b01ca99f51f9473377b95",
+    "symbol": "10wstETH-90MASQ",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1690277878,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd.png",
+        "address": "0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd",
+        "symbol": "wstETH",
+        "weight": "0.1"
+      },
+      {
+        "address": "0xee9a352f6aac4af1a5b9f467f6a93e0ffbe9dd35",
+        "symbol": "MASQ",
+        "weight": "0.9"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x2a60ec04577e0025d177a251d12d39af593e95ae0002000000000000000008cb",
+    "address": "0x2a60ec04577e0025d177a251d12d39af593e95ae",
+    "symbol": "75mooCurveATriCrypto3-25fireFBX",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1668430607,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x5a0801bad20b6c62d86c566ca90688a6b9ea1d3f",
+        "symbol": "mooCurveATriCrypto3",
+        "weight": "0.75"
+      },
+      {
+        "address": "0x960d43be128585ca45365cd74a7773b9d814dfbe",
+        "symbol": "fireFBX",
+        "weight": "0.25"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x924ec7ed38080e40396c46f6206a6d77d0b9f72d00020000000000000000072a",
+    "address": "0x924ec7ed38080e40396c46f6206a6d77d0b9f72d",
+    "symbol": "20WMATIC-80LUCHA",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1661451068,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/137_0x6749441fdc8650b5b5a854ed255c82ef361f1596.png",
+        "address": "0x6749441fdc8650b5b5a854ed255c82ef361f1596",
+        "symbol": "LUCHA",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x4a77ef015ddcd972fd9ba2c7d5d658689d090f1a000000000000000000000b38",
+    "address": "0x4a77ef015ddcd972fd9ba2c7d5d658689d090f1a",
+    "symbol": "wstETH-bb-a-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1681265214,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd.png",
+        "address": "0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x43894de14462b421372bcfe445fa51b1b4a0ff3d.png",
+        "address": "0x43894de14462b421372bcfe445fa51b1b4a0ff3d",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      },
+      {
+        "address": "0x4a77ef015ddcd972fd9ba2c7d5d658689d090f1a",
+        "symbol": "wstETH-bb-a-WETH-BPT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x0d34e5dd4d8f043557145598e4e2dc286b35fd4f000000000000000000000068",
+    "address": "0x0d34e5dd4d8f043557145598e4e2dc286b35fd4f",
+    "symbol": "BPSP-TUSD",
+    "type": "STABLE",
+    "addedTimestamp": 1634659358,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "address": "0x2e1ad108ff1d8c782fcbbb89aad783ac49586756",
+        "symbol": "TUSD",
+        "weight": null
+      },
+      {
+        "address": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
+        "symbol": "DAI",
+        "weight": null
+      },
+      {
+        "address": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+        "symbol": "USDT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x7b90ae8aacf98cb872e5f1cc8e729241c5b8e44d00020000000000000000065b",
+    "address": "0x7b90ae8aacf98cb872e5f1cc8e729241c5b8e44d",
+    "symbol": "20GHST-80TEL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1658327935,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x385eeac5cb85a38a9a07a70c73e0a3271cfb54a7",
+        "symbol": "GHST",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdf7837de1f2fa4631d716cf2502f8b230f1dcc32",
+        "symbol": "TEL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x43894de14462b421372bcfe445fa51b1b4a0ff3d000000000000000000000b36",
+    "address": "0x43894de14462b421372bcfe445fa51b1b4a0ff3d",
+    "symbol": "bb-a-WETH",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1681240132,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x43894de14462b421372bcfe445fa51b1b4a0ff3d.png",
+        "address": "0x43894de14462b421372bcfe445fa51b1b4a0ff3d",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "address": "0xa5bbf0f46b9dc8a43147862ba35c8134eb45f1f5",
+        "symbol": "waWETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x210b1f90dad7236b48b02bc1be099f00dff26d9e000200000000000000000adf",
+    "address": "0x210b1f90dad7236b48b02bc1be099f00dff26d9e",
+    "symbol": "50WMATIC-50FOOT",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1678637910,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": "0.5"
+      },
+      {
+        "address": "0xdd0d1d0a02865e1cb7a01ce42e70f265dc0a5775",
+        "symbol": "FOOT",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x8b03b2416a336a49ee7e2eb9e4248893f9d0ad5400010000000000000000007e",
+    "address": "0x8b03b2416a336a49ee7e2eb9e4248893f9d0ad54",
+    "symbol": "RMP",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1636818858,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": "0.1665"
+      },
+      {
+        "address": "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
+        "symbol": "LINK",
+        "weight": "0.1665"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.1665"
+      },
+      {
+        "address": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
+        "symbol": "DAI",
+        "weight": "0.1675"
+      },
+      {
+        "address": "0x9c2c5fd7b07e95ee044ddeba0e97a665f142394f",
+        "symbol": "1INCH",
+        "weight": "0.1665"
+      },
+      {
+        "address": "0xd6df932a45c0f255f85145f286ea0b292b21c90b",
+        "symbol": "AAVE",
+        "weight": "0.1665"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x402cfdb7781fa85d52f425352661128250b79e12000000000000000000000be3",
+    "address": "0x402cfdb7781fa85d52f425352661128250b79e12",
+    "symbol": "MaticX-bb-a-WMATIC-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689175094,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x402cfdb7781fa85d52f425352661128250b79e12",
+        "symbol": "MaticX-bb-a-WMATIC-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "",
+        "address": "0xb0c830dceb4ef55a60192472c20c8bf19df03488",
+        "symbol": "bb-a-WMATIC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfa68fb4628dff1028cfec22b4162fccd0d45efb6.png",
+        "address": "0xfa68fb4628dff1028cfec22b4162fccd0d45efb6",
+        "symbol": "MaticX",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x415747ee98d482e6dd9b431fa76ad5553744f24700010000000000000000007d",
+    "address": "0x415747ee98d482e6dd9b431fa76ad5553744f247",
+    "symbol": "RAP",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1636759975,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": "0.125"
+      },
+      {
+        "address": "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6",
+        "symbol": "WBTC",
+        "weight": "0.125"
+      },
+      {
+        "address": "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
+        "symbol": "LINK",
+        "weight": "0.125"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.125"
+      },
+      {
+        "address": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
+        "symbol": "DAI",
+        "weight": "0.125"
+      },
+      {
+        "address": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+        "symbol": "BAL",
+        "weight": "0.125"
+      },
+      {
+        "address": "0x9c2c5fd7b07e95ee044ddeba0e97a665f142394f",
+        "symbol": "1INCH",
+        "weight": "0.125"
+      },
+      {
+        "address": "0xd6df932a45c0f255f85145f286ea0b292b21c90b",
+        "symbol": "AAVE",
+        "weight": "0.125"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x82d7f08026e21c7713cfad1071df7c8271b17eae0002000000000000000004b6",
+    "address": "0x82d7f08026e21c7713cfad1071df7c8271b17eae",
+    "symbol": "80MIMO-20PAR",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1650612925,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xadac33f543267c4d59a8c299cf804c303bc3e4ac",
+        "symbol": "MIMO",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/14153/large/par_round_200.png?1614670422",
+        "address": "0xe2aa7db6da1dae97c5f5c6914d285fbfcc32a128",
+        "symbol": "PAR",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xc17636e36398602dd37bb5d1b3a9008c7629005f0002000000000000000004c4",
+    "address": "0xc17636e36398602dd37bb5d1b3a9008c7629005f",
+    "symbol": "B-MaticX-STABLE",
+    "type": "METASTABLE",
+    "addedTimestamp": 1651051393,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfa68fb4628dff1028cfec22b4162fccd0d45efb6.png",
+        "address": "0xfa68fb4628dff1028cfec22b4162fccd0d45efb6",
+        "symbol": "MaticX",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x5a6ae1fd70d04ba4a279fc219dfabc53825cb01d00020000000000000000020e",
+    "address": "0x5a6ae1fd70d04ba4a279fc219dfabc53825cb01d",
+    "symbol": "20WETH-80BANK",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1641489771,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdb7cb471dd0b49b29cab4a1c14d070f27216a0ab",
+        "symbol": "BANK",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x34a81e8956bf20b7448b31990a2c06f96830a6e4000200000000000000000a14",
+    "address": "0x34a81e8956bf20b7448b31990a2c06f96830a6e4",
+    "symbol": "B-wUSDR-STABLE",
+    "type": "METASTABLE",
+    "addedTimestamp": 1673452646,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "address": "0xaf0d9d65fc54de245cda37af3d18cbec860a4d4b",
+        "symbol": "wUSDR",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xb3d658d5b95bf04e2932370dd1ff976fe18dd66a000000000000000000000ace",
+    "address": "0xb3d658d5b95bf04e2932370dd1ff976fe18dd66a",
+    "symbol": "bb-t-USD",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1678371706,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/137_0x7c82a23b4c48d796dee36a9ca215b641c6a8709d.png",
+        "address": "0x7c82a23b4c48d796dee36a9ca215b641c6a8709d",
+        "symbol": "bb-t-USDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae646817e458c0be890b81e8d880206710e3c44e.png",
+        "address": "0xae646817e458c0be890b81e8d880206710e3c44e",
+        "symbol": "bb-t-USDC",
+        "weight": null
+      },
+      {
+        "address": "0xb3d658d5b95bf04e2932370dd1ff976fe18dd66a",
+        "symbol": "bb-t-USD",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/42161_0xda1cd1711743e57dd57102e9e61b75f3587703da.png",
+        "address": "0xda1cd1711743e57dd57102e9e61b75f3587703da",
+        "symbol": "bb-t-DAI",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xfaf3bc722d34146be83a2aac40b43148a51a9126000200000000000000000b4c",
+    "address": "0xfaf3bc722d34146be83a2aac40b43148a51a9126",
+    "symbol": "50KACY-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1682953313,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x366e293a5cf90a0458d9ff9f3f92234da598f62e",
+        "symbol": "KACY",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x614b5038611729ed49e0ded154d8a5d3af9d1d9e00010000000000000000001d",
+    "address": "0x614b5038611729ed49e0ded154d8a5d3af9d1d9e",
+    "symbol": "BP-MTA",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1625852750,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": "0.4"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xf501dd45a1198c2e1b5aef5314a68b9006d842e0",
+        "symbol": "MTA",
+        "weight": "0.4"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xb0c830dceb4ef55a60192472c20c8bf19df03488000000000000000000000be1",
+    "address": "0xb0c830dceb4ef55a60192472c20c8bf19df03488",
+    "symbol": "bb-a-WMATIC",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1689173912,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": null
+      },
+      {
+        "address": "0x6f3913333f2d4b7b01d17bedbce1e4c758b94465",
+        "symbol": "stataPolWMATIC",
+        "weight": null
+      },
+      {
+        "logoURI": "",
+        "address": "0xb0c830dceb4ef55a60192472c20c8bf19df03488",
+        "symbol": "bb-a-WMATIC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc5600020000000000000000001e",
+    "address": "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc56",
+    "symbol": "BP-BTC-SP",
+    "type": "STABLE",
+    "addedTimestamp": 1626300479,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6",
+        "symbol": "WBTC",
+        "weight": null
+      },
+      {
+        "address": "0xdbf31df14b66535af65aac99c32e9ea844e14501",
+        "symbol": "renBTC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x97469e6236bd467cd147065f77752b00efadce8a0002000000000000000008c0",
+    "address": "0x97469e6236bd467cd147065f77752b00efadce8a",
+    "symbol": "ECLP-TUSD-USDC",
+    "type": "GYROE",
+    "addedTimestamp": 1668038053,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "address": "0x2e1ad108ff1d8c782fcbbb89aad783ac49586756",
+        "symbol": "TUSD",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xba07d63875d0c2319d43cbb8a897f89bdafd7e87000100000000000000000077",
+    "address": "0xba07d63875d0c2319d43cbb8a897f89bdafd7e87",
+    "symbol": "RGP",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1636508877,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": "0.125"
+      },
+      {
+        "address": "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
+        "symbol": "LINK",
+        "weight": "0.125"
+      },
+      {
+        "address": "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063",
+        "symbol": "DAI",
+        "weight": "0.125"
+      },
+      {
+        "address": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+        "symbol": "BAL",
+        "weight": "0.125"
+      },
+      {
+        "address": "0x9c2c5fd7b07e95ee044ddeba0e97a665f142394f",
+        "symbol": "1INCH",
+        "weight": "0.125"
+      },
+      {
+        "address": "0xbd7a5cf51d22930b8b3df6d834f9bcef90ee7c4f",
+        "symbol": "ENS",
+        "weight": "0.125"
+      },
+      {
+        "address": "0xd6df932a45c0f255f85145f286ea0b292b21c90b",
+        "symbol": "AAVE",
+        "weight": "0.125"
+      },
+      {
+        "address": "0xdb95f9188479575f3f718a245eca1b3bf74567ec",
+        "symbol": "GTC",
+        "weight": "0.125"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x4973f591784d9c94052a6c3ebd553fcd37bb0e5500020000000000000000087f",
+    "address": "0x4973f591784d9c94052a6c3ebd553fcd37bb0e55",
+    "symbol": "80SD-20maticX",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1667226107,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x1d734a02ef1e1f5886e66b0673b71af5b53ffa94.png",
+        "address": "0x1d734a02ef1e1f5886e66b0673b71af5b53ffa94",
+        "symbol": "SD",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfa68fb4628dff1028cfec22b4162fccd0d45efb6.png",
+        "address": "0xfa68fb4628dff1028cfec22b4162fccd0d45efb6",
+        "symbol": "MaticX",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x9f9f548354b7c66dc9a9f3373077d86aaaccf8f2000200000000000000000a4a",
+    "address": "0x9f9f548354b7c66dc9a9f3373077d86aaaccf8f2",
+    "symbol": "20USDC-80TNGBL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1675443254,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x49e6a20f1bbdfeec2a8222e052000bbb14ee6007",
+        "symbol": "TNGBL",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xc75daa752fb3f160b4c96364f2ee12e3434df655000200000000000000000c31",
+    "address": "0xc75daa752fb3f160b4c96364f2ee12e3434df655",
+    "symbol": "50wstETH-50bIB01",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1693073909,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd.png",
+        "address": "0x03b54a6e9a984069379fae1a4fc4dbae93b3bccd",
+        "symbol": "wstETH",
+        "weight": "0.5"
+      },
+      {
+        "address": "0xca30c93b02514f86d5c86a6e375e3a330b435fb5",
+        "symbol": "bIB01",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x5250525a8fd922ec87b42c42b0ea71fd46565cb0000200000000000000000c1e",
+    "address": "0x5250525a8fd922ec87b42c42b0ea71fd46565cb0",
+    "symbol": "xWARU",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1692040416,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xfa3872970c1952741c518b33f1dce815f55dc00a",
+        "symbol": "WARU",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x8630bd161689403aea635f830e9ef5496e7e0bc1000200000000000000000c35",
+    "address": "0x8630bd161689403aea635f830e9ef5496e7e0bc1",
+    "symbol": "BPT",
+    "type": "FX",
+    "addedTimestamp": 1693966869,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "address": "0xe6a537a407488807f0bbeb0038b79004f19dddfb",
+        "symbol": "BRLA",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x7c82a23b4c48d796dee36a9ca215b641c6a8709d000000000000000000000acd",
+    "address": "0x7c82a23b4c48d796dee36a9ca215b641c6a8709d",
+    "symbol": "bb-t-USDT",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1678371700,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x236975da9f0761e9cf3c2b0f705d705e22829886",
+        "symbol": "tUSDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/137_0x7c82a23b4c48d796dee36a9ca215b641c6a8709d.png",
+        "address": "0x7c82a23b4c48d796dee36a9ca215b641c6a8709d",
+        "symbol": "bb-t-USDT",
+        "weight": null
+      },
+      {
+        "address": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+        "symbol": "USDT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xae646817e458c0be890b81e8d880206710e3c44e000000000000000000000acb",
+    "address": "0xae646817e458c0be890b81e8d880206710e3c44e",
+    "symbol": "bb-t-USDC",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1678371686,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x113f3d54c31ebc71510fd664c8303b34fbc2b355",
+        "symbol": "tUSDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xae646817e458c0be890b81e8d880206710e3c44e.png",
+        "address": "0xae646817e458c0be890b81e8d880206710e3c44e",
+        "symbol": "bb-t-USDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xaf5e0b5425de1f5a630a8cb5aa9d97b8141c908d000200000000000000000366",
+    "address": "0xaf5e0b5425de1f5a630a8cb5aa9d97b8141c908d",
+    "symbol": "B-stMATIC-STABLE",
+    "type": "METASTABLE",
+    "addedTimestamp": 1646261040,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png",
+        "address": "0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4",
+        "symbol": "stMATIC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x8eb46cb3f91a0db4219921374c2af6f3bb5f0bfe000200000000000000000a4d",
+    "address": "0x8eb46cb3f91a0db4219921374c2af6f3bb5f0bfe",
+    "symbol": "20USDC-80AI",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1675614958,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xfa78cba4ebbf8fe28b4fc1468948f16fda2752b3",
+        "symbol": "AI",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xd00f9ca46ce0e4a63067c4657986f0167b0de1e5000000000000000000000b42",
+    "address": "0xd00f9ca46ce0e4a63067c4657986f0167b0de1e5",
+    "symbol": "frxETH-bb-a-WETH",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1681435723,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x43894de14462b421372bcfe445fa51b1b4a0ff3d.png",
+        "address": "0x43894de14462b421372bcfe445fa51b1b4a0ff3d",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      },
+      {
+        "address": "0xd00f9ca46ce0e4a63067c4657986f0167b0de1e5",
+        "symbol": "frxETH-bb-a-WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xee327f889d5947c1dc1934bb208a1e792f953e96.png",
+        "address": "0xee327f889d5947c1dc1934bb208a1e792f953e96",
+        "symbol": "frxETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xac2cae8d2f78a4a8f92f20dbe74042cd0a8d5af3000000000000000000000be2",
+    "address": "0xac2cae8d2f78a4a8f92f20dbe74042cd0a8d5af3",
+    "symbol": "stMATIC-bb-a-WMATIC-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689174874,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4.png",
+        "address": "0x3a58a54c066fdc0f2d55fc9c89f0415c92ebf3c4",
+        "symbol": "stMATIC",
+        "weight": null
+      },
+      {
+        "address": "0xac2cae8d2f78a4a8f92f20dbe74042cd0a8d5af3",
+        "symbol": "stMATIC-bb-a-WMATIC-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "",
+        "address": "0xb0c830dceb4ef55a60192472c20c8bf19df03488",
+        "symbol": "bb-a-WMATIC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xf461f2240b66d55dcf9059e26c022160c06863bf000100000000000000000006",
+    "address": "0xf461f2240b66d55dcf9059e26c022160c06863bf",
+    "symbol": "B-QIPOOL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1624483747,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/polygon/assets/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174/logo.png",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "symbol": "USDC",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/15329/large/qi.png?1620540969",
+        "address": "0x580a84c73811e1839f75d86d75d88cca0c241ff4",
+        "symbol": "QI",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+        "symbol": "BAL",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xa3fa99a148fa48d14ed51d610c367c61876997f1",
+        "symbol": "miMATIC",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x61d5dc44849c9c87b0856a2a311536205c96c7fd000200000000000000000000",
+    "address": "0x61d5dc44849c9c87b0856a2a311536205c96c7fd",
+    "symbol": "B-50WMATIC-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1624142837,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270.png",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "symbol": "WMATIC",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x8fbd0f8e490735cfc3abf4f29cbddd5c3289b9a7000000000000000000000b5b",
+    "address": "0x8fbd0f8e490735cfc3abf4f29cbddd5c3289b9a7",
+    "symbol": "FRAX-bb-am-USD",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1683545627,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x45c32fa6df82ead1e2ef74d17b76547eddfaff89.png",
+        "address": "0x45c32fa6df82ead1e2ef74d17b76547eddfaff89",
+        "symbol": "FRAX",
+        "weight": null
+      },
+      {
+        "address": "0x8fbd0f8e490735cfc3abf4f29cbddd5c3289b9a7",
+        "symbol": "FRAX-bb-am-USD",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xb371aa09f5a110ab69b39a84b5469d29f9b22b76.png",
+        "address": "0xb371aa09f5a110ab69b39a84b5469d29f9b22b76",
+        "symbol": "bb-am-USD",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0x7d60a4cb5ca92e2da965637025122296ea6854f900000000000000000000085e",
+    "address": "0x7d60a4cb5ca92e2da965637025122296ea6854f9",
+    "symbol": "2EUR (PAR)",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1666541785,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4e3decbb3645551b8a19f0ea1678079fcb33fb4c.png",
+        "address": "0x4e3decbb3645551b8a19f0ea1678079fcb33fb4c",
+        "symbol": "jEUR",
+        "weight": null
+      },
+      {
+        "address": "0x7d60a4cb5ca92e2da965637025122296ea6854f9",
+        "symbol": "2EUR (PAR)",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/14153/large/par_round_200.png?1614670422",
+        "address": "0xe2aa7db6da1dae97c5f5c6914d285fbfcc32a128",
+        "symbol": "PAR",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xe22483774bd8611be2ad2f4194078dac9159f4ba0000000000000000000008f0",
+    "address": "0xe22483774bd8611be2ad2f4194078dac9159f4ba",
+    "symbol": "2BRL (BRZ)",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1668778434,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x491a4eb4f1fc3bff8e1d2fc856a6a46663ad556f.png",
+        "address": "0x491a4eb4f1fc3bff8e1d2fc856a6a46663ad556f",
+        "symbol": "BRZ",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xe22483774bd8611be2ad2f4194078dac9159f4ba.png",
+        "address": "0xe22483774bd8611be2ad2f4194078dac9159f4ba",
+        "symbol": "2BRL (BRZ)",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf2f77fe7b8e66571e0fca7104c4d670bf1c8d722.png",
+        "address": "0xf2f77fe7b8e66571e0fca7104c4d670bf1c8d722",
+        "symbol": "jBRL",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "POLYGON",
+    "id": "0xcb5f651cda3bd979c9883c61a1cc6395d9556415000200000000000000000947",
+    "address": "0xcb5f651cda3bd979c9883c61a1cc6395d9556415",
+    "symbol": "50TUSD-50miMATIC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1670357007,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x2e1ad108ff1d8c782fcbbb89aad783ac49586756",
+        "symbol": "TUSD",
+        "weight": "0.5"
+      },
+      {
+        "address": "0xa3fa99a148fa48d14ed51d610c367c61876997f1",
+        "symbol": "miMATIC",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "ZKEVM",
+    "id": "0xe1f2c039a68a216de6dd427be6c60decf405762a00000000000000000000000e",
+    "address": "0xe1f2c039a68a216de6dd427be6c60decf405762a",
+    "symbol": "B-wstETH-STABLE",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1686236867,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9.png",
+        "address": "0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5d8cff95d7a57c0bf50b30b43c7cc0d52825d4a9.png",
+        "address": "0x5d8cff95d7a57c0bf50b30b43c7cc0d52825d4a9",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "address": "0xe1f2c039a68a216de6dd427be6c60decf405762a",
+        "symbol": "B-wstETH-STABLE",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ZKEVM",
+    "id": "0x1d0a8a31cdb04efac3153237526fb15cc65a252000000000000000000000000f",
+    "address": "0x1d0a8a31cdb04efac3153237526fb15cc65a2520",
+    "symbol": "B-rETH-STABLE",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1686237030,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x1d0a8a31cdb04efac3153237526fb15cc65a2520",
+        "symbol": "B-rETH-STABLE",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9.png",
+        "address": "0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xb23c20efce6e24acca0cef9b7b7aa196b84ec942.png",
+        "address": "0xb23c20efce6e24acca0cef9b7b7aa196b84ec942",
+        "symbol": "rETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ZKEVM",
+    "id": "0xdf725fde6e89981fb30d9bf999841ac2c160b512000000000000000000000010",
+    "address": "0xdf725fde6e89981fb30d9bf999841ac2c160b512",
+    "symbol": "B-wstETH/rETH-STABLE",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1686237250,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5d8cff95d7a57c0bf50b30b43c7cc0d52825d4a9.png",
+        "address": "0x5d8cff95d7a57c0bf50b30b43c7cc0d52825d4a9",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xb23c20efce6e24acca0cef9b7b7aa196b84ec942.png",
+        "address": "0xb23c20efce6e24acca0cef9b7b7aa196b84ec942",
+        "symbol": "rETH",
+        "weight": null
+      },
+      {
+        "address": "0xdf725fde6e89981fb30d9bf999841ac2c160b512",
+        "symbol": "B-wstETH/rETH-STABLE",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ZKEVM",
+    "id": "0xa4475aa0a6971e3cc82de08e9ce432ecc8a562ad000200000000000000000029",
+    "address": "0xa4475aa0a6971e3cc82de08e9ce432ecc8a562ad",
+    "symbol": "50BAL-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1690201140,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x120ef59b80774f02211563834d8e3b72cb1649d6",
+        "symbol": "BAL",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9.png",
+        "address": "0x4f9a0e7fd2bf6067db6994cf12e4495df938e6e9",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x32df62dc3aed2cd6224193052ce665dc181658410002000000000000000003bd",
+    "address": "0x32df62dc3aed2cd6224193052ce665dc18165841",
+    "symbol": "RDNT-WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1679182811,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1658715865",
+        "address": "0x3082cc23568ea640225c2467653db90e9250aaa0",
+        "symbol": "RDNT",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x9791d590788598535278552eecd4b211bfc790cb000000000000000000000498",
+    "address": "0x9791d590788598535278552eecd4b211bfc790cb",
+    "symbol": "wstETH-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692037583,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "address": "0x9791d590788598535278552eecd4b211bfc790cb",
+        "symbol": "wstETH-WETH-BPT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x423a1323c871abc9d89eb06855bf5347048fc4a5000000000000000000000496",
+    "address": "0x423a1323c871abc9d89eb06855bf5347048fc4a5",
+    "symbol": "4POOL-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692036997,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "",
+        "address": "0x423a1323c871abc9d89eb06855bf5347048fc4a5",
+        "symbol": "4POOL-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+        "symbol": "DAI",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9.png",
+        "address": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+        "symbol": "USDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "symbol": "USDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xbcaa6c053cab3dd73a2e898d89a4f84a180ae1ca000100000000000000000458",
+    "address": "0xbcaa6c053cab3dd73a2e898d89a4f84a180ae1ca",
+    "symbol": "33AURA-33ARB-33BAL",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1687167274,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba100000625a3754423978a60c9317c58a424e3d.png",
+        "address": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+        "symbol": "BAL",
+        "weight": "0.333333333333333333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x1509706a6c66ca549ff0cb464de88231ddbe213b.png",
+        "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
+        "symbol": "AURA",
+        "weight": "0.333333333333333333"
+      },
+      {
+        "address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+        "symbol": "ARB",
+        "weight": "0.333333333333333334"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xade4a71bb62bec25154cfc7e6ff49a513b491e81000000000000000000000497",
+    "address": "0xade4a71bb62bec25154cfc7e6ff49a513b491e81",
+    "symbol": "rETH-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692037305,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "address": "0xade4a71bb62bec25154cfc7e6ff49a513b491e81",
+        "symbol": "rETH-WETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8.png",
+        "address": "0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8",
+        "symbol": "rETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xc9f52540976385a84bf416903e1ca3983c539e34000200000000000000000434",
+    "address": "0xc9f52540976385a84bf416903e1ca3983c539e34",
+    "symbol": "50tBTC-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1684203356,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40.png",
+        "address": "0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40",
+        "symbol": "tBTC",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x542f16da0efb162d20bf4358efa095b70a100f9e000000000000000000000436",
+    "address": "0x542f16da0efb162d20bf4358efa095b70a100f9e",
+    "symbol": "2BTC",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1684284153,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
+        "symbol": "WBTC",
+        "weight": null
+      },
+      {
+        "address": "0x542f16da0efb162d20bf4358efa095b70a100f9e",
+        "symbol": "2BTC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40.png",
+        "address": "0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40",
+        "symbol": "tBTC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x3fd4954a851ead144c2ff72b1f5a38ea5976bd54000000000000000000000480",
+    "address": "0x3fd4954a851ead144c2ff72b1f5a38ea5976bd54",
+    "symbol": "ankrETH/wstETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689817378,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x3fd4954a851ead144c2ff72b1f5a38ea5976bd54",
+        "symbol": "ankrETH/wstETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/13403/large/aETHc.png?1625756490",
+        "address": "0xe05a08226c49b636acf99c40da8dc6af83ce5bb3",
+        "symbol": "ankrETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x4a2f6ae7f3e5d715689530873ec35593dc28951b000000000000000000000481",
+    "address": "0x4a2f6ae7f3e5d715689530873ec35593dc28951b",
+    "symbol": "wstETH/rETH/cbETH",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689904195,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png?1661390066",
+        "address": "0x1debd73e752beaf79865fd6446b0c970eae7732f",
+        "symbol": "cbETH",
+        "weight": null
+      },
+      {
+        "address": "0x4a2f6ae7f3e5d715689530873ec35593dc28951b",
+        "symbol": "wstETH/rETH/cbETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8.png",
+        "address": "0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8",
+        "symbol": "rETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x36bf227d6bac96e2ab1ebb5492ecec69c691943f000200000000000000000316",
+    "address": "0x36bf227d6bac96e2ab1ebb5492ecec69c691943f",
+    "symbol": "B-wstETH-WETH-Stable",
+    "type": "METASTABLE",
+    "addedTimestamp": 1673459039,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x3a4c6d2404b5eb14915041e01f63200a82f4a343000200000000000000000065",
+    "address": "0x3a4c6d2404b5eb14915041e01f63200a82f4a343",
+    "symbol": "50STG-50USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1647622160,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6694340fc020c5e6b96567843da2df01b2ce1eb6.png",
+        "address": "0x6694340fc020c5e6b96567843da2df01b2ce1eb6",
+        "symbol": "STG",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "symbol": "USDC",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xb3028ca124b80cfe6e9ca57b70ef2f0ccc41ebd40002000000000000000000ba",
+    "address": "0xb3028ca124b80cfe6e9ca57b70ef2f0ccc41ebd4",
+    "symbol": "50MAGIC-50USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1657137806,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x539bde0d7dbd336b79148aa742883198bbf60342.png",
+        "address": "0x539bde0d7dbd336b79148aa742883198bbf60342",
+        "symbol": "MAGIC",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "symbol": "USDC",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x8bc65eed474d1a00555825c91feab6a8255c2107000000000000000000000453",
+    "address": "0x8bc65eed474d1a00555825c91feab6a8255c2107",
+    "symbol": "DOLA/USDC BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1686700875,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/14287/large/dola.png?1667738374",
+        "address": "0x6a7661795c374c0bfc635934efaddff3a7ee23b6",
+        "symbol": "DOLA",
+        "weight": null
+      },
+      {
+        "address": "0x8bc65eed474d1a00555825c91feab6a8255c2107",
+        "symbol": "DOLA/USDC BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+        "symbol": "USDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x569061e2d807881f4a33e1cbe1063bc614cb75a40002000000000000000002bb",
+    "address": "0x569061e2d807881f4a33e1cbe1063bc614cb75a4",
+    "symbol": "80Y2K-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1671474257,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x65c936f008bc34fe819bce9fa5afd9dc2d49977f",
+        "symbol": "Y2K",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x64541216bafffeec8ea535bb71fbc927831d0595000100000000000000000002",
+    "address": "0x64541216bafffeec8ea535bb71fbc927831d0595",
+    "symbol": "B-33WETH-33WBTC-33USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1630354547,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
+        "symbol": "WBTC",
+        "weight": "0.333333333333333333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.333333333333333334"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "symbol": "USDC",
+        "weight": "0.333333333333333333"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xc7fa3a3527435720f0e2a4c1378335324dd4f9b3000200000000000000000459",
+    "address": "0xc7fa3a3527435720f0e2a4c1378335324dd4f9b3",
+    "symbol": "55auraBal-45wsteth",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1687171500,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x223738a747383d6f9f827d95964e4d8e8ac754ce.png",
+        "address": "0x223738a747383d6f9f827d95964e4d8e8ac754ce",
+        "symbol": "auraBAL",
+        "weight": "0.55"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": "0.45"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x45c4d1376943ab28802b995acffc04903eb5223f000000000000000000000470",
+    "address": "0x45c4d1376943ab28802b995acffc04903eb5223f",
+    "symbol": "wstETH-bb-a-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689175700,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x45c4d1376943ab28802b995acffc04903eb5223f",
+        "symbol": "wstETH-bb-a-WETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "",
+        "address": "0xad28940024117b442a9efb6d0f25c8b59e1c950b",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xc61ff48f94d801c1ceface0289085197b5ec44f000020000000000000000004d",
+    "address": "0xc61ff48f94d801c1ceface0289085197b5ec44f0",
+    "symbol": "50VSTA-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1644359393,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.5"
+      },
+      {
+        "address": "0xa684cd057951541187f288294a1e1c2646aa2d24",
+        "symbol": "VSTA",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xead7e0163e3b33bf0065c9325fc8fb9b18cc82130000000000000000000004a9",
+    "address": "0xead7e0163e3b33bf0065c9325fc8fb9b18cc8213",
+    "symbol": "STAR/USDC-BPT ",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1693363065,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc19669a405067927865b40ea045a2baabbbe57f5.png",
+        "address": "0xc19669a405067927865b40ea045a2baabbbe57f5",
+        "symbol": "STAR",
+        "weight": null
+      },
+      {
+        "address": "0xead7e0163e3b33bf0065c9325fc8fb9b18cc8213",
+        "symbol": "STAR/USDC-BPT ",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xd449efa0a587f2cb6be3ae577bc167a7745258100001000000000000000003f4",
+    "address": "0xd449efa0a587f2cb6be3ae577bc167a774525810",
+    "symbol": "BPT-OG",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1680408590,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x80bb30d62a16e1f2084deae84dc293531c3ac3a1",
+        "symbol": "GRAIN",
+        "weight": "0.35"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.15"
+      },
+      {
+        "address": "0xa1150db5105987cec5fd092273d1e3cbb22b378b",
+        "symbol": "OATH",
+        "weight": "0.35"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "symbol": "USDC",
+        "weight": "0.15"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xcba9ff45cfb9ce238afde32b0148eb82cbe635620000000000000000000003fd",
+    "address": "0xcba9ff45cfb9ce238afde32b0148eb82cbe63562",
+    "symbol": "rETH-bb-a-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1680695434,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0xcba9ff45cfb9ce238afde32b0148eb82cbe63562",
+        "symbol": "rETH-bb-a-WETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/42161_0xda1cd1711743e57dd57102e9e61b75f3587703da.png",
+        "address": "0xda1cd1711743e57dd57102e9e61b75f3587703da",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8.png",
+        "address": "0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8",
+        "symbol": "rETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xda1cd1711743e57dd57102e9e61b75f3587703da0000000000000000000003fc",
+    "address": "0xda1cd1711743e57dd57102e9e61b75f3587703da",
+    "symbol": "bb-a-WETH",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1680693031,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x18c100415988bef4354effad1188d1c22041b046",
+        "symbol": "waWETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/42161_0xda1cd1711743e57dd57102e9e61b75f3587703da.png",
+        "address": "0xda1cd1711743e57dd57102e9e61b75f3587703da",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x1533a3278f3f9141d5f820a184ea4b017fce2382000000000000000000000016",
+    "address": "0x1533a3278f3f9141d5f820a184ea4b017fce2382",
+    "symbol": "B-staBAL-3",
+    "type": "STABLE",
+    "addedTimestamp": 1632409978,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+        "symbol": "DAI",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9.png",
+        "address": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+        "symbol": "USDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "symbol": "USDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xad28940024117b442a9efb6d0f25c8b59e1c950b00000000000000000000046f",
+    "address": "0xad28940024117b442a9efb6d0f25c8b59e1c950b",
+    "symbol": "bb-a-WETH",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1689175387,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x18468b6eba332285c6d9bb03fe7fb52e108c4596",
+        "symbol": "stataArbWETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "",
+        "address": "0xad28940024117b442a9efb6d0f25c8b59e1c950b",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xfb5e6d0c1dfed2ba000fbc040ab8df3615ac329c000000000000000000000159",
+    "address": "0xfb5e6d0c1dfed2ba000fbc040ab8df3615ac329c",
+    "symbol": "B-stETH-Stable",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1663446291,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "address": "0xfb5e6d0c1dfed2ba000fbc040ab8df3615ac329c",
+        "symbol": "B-stETH-Stable",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xcc65a812ce382ab909a11e434dbf75b34f1cc59d000200000000000000000001",
+    "address": "0xcc65a812ce382ab909a11e434dbf75b34f1cc59d",
+    "symbol": "B-60BAL-40WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1630353781,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba100000625a3754423978a60c9317c58a424e3d.png",
+        "address": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+        "symbol": "BAL",
+        "weight": "0.6"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.4"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x4f14d06cb1661ce1dc2a2f26a10a7cd94393b29c000200000000000000000097",
+    "address": "0x4f14d06cb1661ce1dc2a2f26a10a7cd94393b29c",
+    "symbol": "20fxUSD-80FOREX",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1653699545,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x8616e8ea83f048ab9a5ec513c9412dd2993bce3f",
+        "symbol": "fxUSD",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xdb298285fe4c5410b05390ca80e8fbe9de1f259b",
+        "symbol": "FOREX",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x8d333f82e0693f53fa48c40d5d4547142e907e1d000200000000000000000437",
+    "address": "0x8d333f82e0693f53fa48c40d5d4547142e907e1d",
+    "symbol": "80PAL-20OHM",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1684333627,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "",
+        "address": "0xa7997f0ec9fa54e89659229fb26537b6a725b798",
+        "symbol": "PAL",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/14483/large/token_OHM_%281%29.png?1628311611",
+        "address": "0xf0cb2dc0db5e6c66b9a70ac27b06b878da017028",
+        "symbol": "OHM",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xb5bd58c733948e3d65d86ba9604e06e5da276fd10002000000000000000003e6",
+    "address": "0xb5bd58c733948e3d65d86ba9604e06e5da276fd1",
+    "symbol": "WBTC-wstETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1679709755,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
+        "symbol": "WBTC",
+        "weight": "0.87"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": "0.13"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x3caff0e4ef5ab37081503aca2c65e859aa026ab50002000000000000000000b7",
+    "address": "0x3caff0e4ef5ab37081503aca2c65e859aa026ab5",
+    "symbol": "20WETH-80BICO",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1656686702,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xa68ec98d7ca870cf1dd0b00ebbb7c4bf60a8e74d",
+        "symbol": "BICO",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xbe0f30217be1e981add883848d0773a86d2d2cd4000000000000000000000471",
+    "address": "0xbe0f30217be1e981add883848d0773a86d2d2cd4",
+    "symbol": "rETH-bb-a-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689176610,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "",
+        "address": "0xad28940024117b442a9efb6d0f25c8b59e1c950b",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      },
+      {
+        "address": "0xbe0f30217be1e981add883848d0773a86d2d2cd4",
+        "symbol": "rETH-bb-a-WETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8.png",
+        "address": "0xec70dcb4a1efa46b8f2d97c310c9c4790ba5ffa8",
+        "symbol": "rETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xc2f082d33b5b8ef3a7e3de30da54efd3114512ac000200000000000000000017",
+    "address": "0xc2f082d33b5b8ef3a7e3de30da54efd3114512ac",
+    "symbol": "B-80PICKLE-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1632413358,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x965772e0e9c84b6f359c8597c891108dcf1c5b1a",
+        "symbol": "PICKLE",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x178e029173417b1f9c8bc16dcec6f697bc323746000200000000000000000158",
+    "address": "0x178e029173417b1f9c8bc16dcec6f697bc323746",
+    "symbol": "50WSTETH-50USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1663445407,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "symbol": "USDC",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xd89746affa5483627a87e55713ec1905114394950002000000000000000000bf",
+    "address": "0xd89746affa5483627a87e55713ec190511439495",
+    "symbol": "DUSDDAI",
+    "type": "STABLE",
+    "addedTimestamp": 1659533296,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+        "symbol": "DAI",
+        "weight": null
+      },
+      {
+        "address": "0xf0b5ceefc89684889e5f7e0a7775bd100fcd3709",
+        "symbol": "DUSD",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x17a35e3d578797e34131d10e66c11170848c6da100010000000000000000001d",
+    "address": "0x17a35e3d578797e34131d10e66c11170848c6da1",
+    "symbol": "33 1S-BTC 33 1L-BTC 33 USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1632706493,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x052814194f459af30edb6a506eabfc85a4d99501",
+        "symbol": "1S-BTC/USD",
+        "weight": "0.333"
+      },
+      {
+        "address": "0x1616bf7bbd60e57f961e83a602b6b9abb6e6cafc",
+        "symbol": "1L-BTC/USD",
+        "weight": "0.333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "symbol": "USDC",
+        "weight": "0.334"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x3f09c77b19ad8bb527355ec32d5ce98421fec2e30000000000000000000004b2",
+    "address": "0x3f09c77b19ad8bb527355ec32d5ce98421fec2e3",
+    "symbol": "axlBAL/BAL",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1695082456,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba100000625a3754423978a60c9317c58a424e3d.png",
+        "address": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+        "symbol": "BAL",
+        "weight": null
+      },
+      {
+        "logoURI": "",
+        "address": "0x11c1879227d463b60db18c17c20ae739ae8e961a",
+        "symbol": "axlBAL",
+        "weight": null
+      },
+      {
+        "address": "0x3f09c77b19ad8bb527355ec32d5ce98421fec2e3",
+        "symbol": "axlBAL/BAL",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xa231aea07bb5e79ae162f95903806fc5ad65ff1100020000000000000000043f",
+    "address": "0xa231aea07bb5e79ae162f95903806fc5ad65ff11",
+    "symbol": "50DFX-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1684929789,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/14091/large/DFX.png?1614320944",
+        "address": "0xa4914b824ef261d4ed0ccecec29500862d57c0a1",
+        "symbol": "DFX",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x7f244b47c63e9ca33a58e6550bfd1d3dc806ce550002000000000000000003fa",
+    "address": "0x7f244b47c63e9ca33a58e6550bfd1d3dc806ce55",
+    "symbol": "CHEESE",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1680559234,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.05"
+      },
+      {
+        "address": "0xd2cc61a36c31425b3eb9bbeecce74a82a2e32e27",
+        "symbol": "RATS",
+        "weight": "0.95"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x93b48e950380adcf6d67c392f20d44fb88d258dc000200000000000000000465",
+    "address": "0x93b48e950380adcf6d67c392f20d44fb88d258dc",
+    "symbol": "50USDC-50USDC.e",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1687516255,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+        "symbol": "USDC",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "symbol": "USDC",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xc85d90dec1e12edee418c445b381e7168eb380ab0001000000000000000003e3",
+    "address": "0xc85d90dec1e12edee418c445b381e7168eb380ab",
+    "symbol": "29WBTC-4wstETH-67ARB",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1679702883,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
+        "symbol": "WBTC",
+        "weight": "0.29"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": "0.0433"
+      },
+      {
+        "address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+        "symbol": "ARB",
+        "weight": "0.6667"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x0adeb25cb5920d4f7447af4a0428072edc2cee2200020000000000000000004a",
+    "address": "0x0adeb25cb5920d4f7447af4a0428072edc2cee22",
+    "symbol": "80GMX-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1644032654,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a",
+        "symbol": "GMX",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x5a7f39435fd9c381e4932fa2047c9a5136a5e3e7000000000000000000000400",
+    "address": "0x5a7f39435fd9c381e4932fa2047c9a5136a5e3e7",
+    "symbol": "wstETH-bb-a-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1681142907,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "address": "0x5a7f39435fd9c381e4932fa2047c9a5136a5e3e7",
+        "symbol": "wstETH-bb-a-WETH-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/42161_0xda1cd1711743e57dd57102e9e61b75f3587703da.png",
+        "address": "0xda1cd1711743e57dd57102e9e61b75f3587703da",
+        "symbol": "bb-a-WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x651e00ffd5ecfa7f3d4f33d62ede0a97cf62ede2000200000000000000000006",
+    "address": "0x651e00ffd5ecfa7f3d4f33d62ede0a97cf62ede2",
+    "symbol": "B-80LINK-20WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1630414571,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
+        "symbol": "LINK",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x6ee86e032173716a41818e6d6d320a752176d69700010000000000000000001c",
+    "address": "0x6ee86e032173716a41818e6d6d320a752176d697",
+    "symbol": "33 1S-ETH 33 1L-ETH 33 USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1632706337,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x38c0a5443c7427e65a9bf15ae746a28bb9a052cc",
+        "symbol": "1L-ETH/USD",
+        "weight": "0.333"
+      },
+      {
+        "address": "0xf581571dbcced3a59aaacbf90448e7b3e1704dcd",
+        "symbol": "1S-ETH/USD",
+        "weight": "0.333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "symbol": "USDC",
+        "weight": "0.334"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xc764b55852f8849ae69923e45ce077a576bf9a8d0002000000000000000003d7",
+    "address": "0xc764b55852f8849ae69923e45ce077a576bf9a8d",
+    "symbol": "20WETH-80ARB",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1679598383,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+        "symbol": "ARB",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x0052688295413b32626d226a205b95cdb337de860002000000000000000003d1",
+    "address": "0x0052688295413b32626d226a205b95cdb337de86",
+    "symbol": "20ARB-80USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1679581018,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+        "symbol": "ARB",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "symbol": "USDC",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xc6eee8cb7643ec2f05f46d569e9ec8ef8b41b389000000000000000000000475",
+    "address": "0xc6eee8cb7643ec2f05f46d569e9ec8ef8b41b389",
+    "symbol": "bb-a-USD",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689181646,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6cb787a419c3e6ee2e9ff365856c29cd10659113.png",
+        "address": "0x6cb787a419c3e6ee2e9ff365856c29cd10659113",
+        "symbol": "bb-a-DAI",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbd724eb087d4cc0f61a5fed1fffaf937937e14de.png",
+        "address": "0xbd724eb087d4cc0f61a5fed1fffaf937937e14de",
+        "symbol": "bb-a-USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xc46be4b8bb6b5a3d3120660efae9c5416318ed40.png",
+        "address": "0xc46be4b8bb6b5a3d3120660efae9c5416318ed40",
+        "symbol": "bb-a-USDT",
+        "weight": null
+      },
+      {
+        "logoURI": "",
+        "address": "0xc6eee8cb7643ec2f05f46d569e9ec8ef8b41b389",
+        "symbol": "bb-a-USD",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x0a6eb487db5a1aeb35d3d9fce9a32fbb943d186d00010000000000000000044a",
+    "address": "0x0a6eb487db5a1aeb35d3d9fce9a32fbb943d186d",
+    "symbol": "PERPETUALS",
+    "type": "MANAGED",
+    "addedTimestamp": 1686247847,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x088cd8f5ef3652623c22d48b1605dcfe860cd704",
+        "symbol": "VELA",
+        "weight": null
+      },
+      {
+        "address": "0x0a6eb487db5a1aeb35d3d9fce9a32fbb943d186d",
+        "symbol": "PERPETUALS",
+        "weight": null
+      },
+      {
+        "address": "0x164731cd270daa4a94bc70761e53320e48367b8b",
+        "symbol": "Array",
+        "weight": null
+      },
+      {
+        "address": "0x18c11fd286c5ec11c3b683caa813b77f5163a122",
+        "symbol": "GNS",
+        "weight": null
+      },
+      {
+        "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
+        "symbol": "MCB",
+        "weight": null
+      },
+      {
+        "address": "0xf9df075716b2d9b95616341dc6bc64c85e56645c",
+        "symbol": "$MAY",
+        "weight": null
+      },
+      {
+        "address": "0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a",
+        "symbol": "GMX",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x8a88c1f44854c61a466ab55614f6a7778473418b0001000000000000000003e5",
+    "address": "0x8a88c1f44854c61a466ab55614f6a7778473418b",
+    "symbol": "29WBTC-4wstETH-67LINK",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1679709437,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
+        "symbol": "WBTC",
+        "weight": "0.29"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": "0.0433"
+      },
+      {
+        "address": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
+        "symbol": "LINK",
+        "weight": "0.6667"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xb5b77f1ad2b520df01612399258e7787af63025d000200000000000000000010",
+    "address": "0xb5b77f1ad2b520df01612399258e7787af63025d",
+    "symbol": "MWP",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1631188530,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x4e352cf164e64adcbad318c3a1e222e9eba4ce42",
+        "symbol": "MCB",
+        "weight": "0.6"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.4"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x996616bde0cb4974e571f17d31c844da2bd177f8000100000000000000000018",
+    "address": "0x996616bde0cb4974e571f17d31c844da2bd177f8",
+    "symbol": "50 wETH 33 3S-ETH 17 3L-ETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1632443262,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x7d7e4f49a29dda8b1ecdcf8a8bc85edcb234e997",
+        "symbol": "3S-ETH/USD",
+        "weight": "0.3333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.5"
+      },
+      {
+        "address": "0xaa846004dc01b532b63feaa0b7a0cb0990f19ed9",
+        "symbol": "3L-ETH/USD",
+        "weight": "0.1667"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xd1566767047dd97395f0ec1d88ec614d0a93adf00001000000000000000003e4",
+    "address": "0xd1566767047dd97395f0ec1d88ec614d0a93adf0",
+    "symbol": "LDO-WBTC-wstETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1679708587,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x13ad51ed4f1b7e9dc168d8a00cb3f4ddd85efa60",
+        "symbol": "LDO",
+        "weight": "0.6667"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
+        "symbol": "WBTC",
+        "weight": "0.29"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": "0.0433"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xf17f1e67bc384e43b4acf69cc032ad086f15f2620002000000000000000003c6",
+    "address": "0xf17f1e67bc384e43b4acf69cc032ad086f15f262",
+    "symbol": "20WETH-80AI",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1679406108,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x8d7c2588c365b9e98ea464b63dbccdf13ecd9809",
+        "symbol": "AI",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x59b7867f6b127070378feeb328e2ffe6aab6752500010000000000000000009b",
+    "address": "0x59b7867f6b127070378feeb328e2ffe6aab67525",
+    "symbol": "33 USDC 33 3L-ETH+USDC 33 3S-ETH+USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1654144527,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x4d00c6dd5d5299082a1062c9b480af2fc698f6eb",
+        "symbol": "3L-ETH/USD+USDC",
+        "weight": "0.3333"
+      },
+      {
+        "address": "0x7ff6132ef2abf89b6ec509947eb2c1ee9da29f26",
+        "symbol": "3S-ETH/USD+USDC",
+        "weight": "0.3333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "symbol": "USDC",
+        "weight": "0.3334"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xc1889c72d99917fd7b957fed80d4ea1ebd9e26180001000000000000000000ae",
+    "address": "0xc1889c72d99917fd7b957fed80d4ea1ebd9e2618",
+    "symbol": "25BAL-25WBTC-25PHONON-25WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1655915091,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba100000625a3754423978a60c9317c58a424e3d.png",
+        "address": "0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8",
+        "symbol": "BAL",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png",
+        "address": "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f",
+        "symbol": "WBTC",
+        "weight": "0.25"
+      },
+      {
+        "address": "0x39a49bc5017fc668299cd32e734c9269acc35295",
+        "symbol": "PHONON",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": "0.25"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x85a7023f3d287f849b6c8223af1e783383a391a8000200000000000000000044",
+    "address": "0x85a7023f3d287f849b6c8223af1e783383a391a8",
+    "symbol": "50LEVR-50DAI",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1643878946,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x77de4df6f2d87cc7708959bcea45d58b0e8b8315",
+        "symbol": "LEVR",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+        "symbol": "DAI",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0xf43ab4cbe4999309d7c8077ad99f52c78cc495e6000100000000000000000449",
+    "address": "0xf43ab4cbe4999309d7c8077ad99f52c78cc495e6",
+    "symbol": "ALTCOIN",
+    "type": "MANAGED",
+    "addedTimestamp": 1686247709,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x11cdb42b0eb46d95f990bedd4695a6e3fa034978",
+        "symbol": "CRV",
+        "weight": null
+      },
+      {
+        "address": "0x164731cd270daa4a94bc70761e53320e48367b8b",
+        "symbol": "Array",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1658715865",
+        "address": "0x3082cc23568ea640225c2467653db90e9250aaa0",
+        "symbol": "RDNT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+        "address": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+        "symbol": "ARB",
+        "weight": null
+      },
+      {
+        "address": "0xba5ddd1f9d7f570dc94a51479a000e3bce967196",
+        "symbol": "AAVE",
+        "weight": null
+      },
+      {
+        "address": "0xf43ab4cbe4999309d7c8077ad99f52c78cc495e6",
+        "symbol": "ALTCOIN",
+        "weight": null
+      },
+      {
+        "address": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
+        "symbol": "LINK",
+        "weight": null
+      },
+      {
+        "address": "0xf9df075716b2d9b95616341dc6bc64c85e56645c",
+        "symbol": "$MAY",
+        "weight": null
+      },
+      {
+        "address": "0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0",
+        "symbol": "UNI",
+        "weight": null
+      },
+      {
+        "address": "0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a",
+        "symbol": "GMX",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "ARBITRUM",
+    "id": "0x6f3b31296fd2457eba6dca3bed65ec79e06c12950001000000000000000003f2",
+    "address": "0x6f3b31296fd2457eba6dca3bed65ec79e06c1295",
+    "symbol": "17RDNT-17wstETH-17STG-17ARB-17GMX-17USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1680024662,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/26536/large/Radiant-Logo-200x200.png?1658715865",
+        "address": "0x3082cc23568ea640225c2467653db90e9250aaa0",
+        "symbol": "RDNT",
+        "weight": "0.1666"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x5979d7b546e38e414f7e9822514be443a4800529.png",
+        "address": "0x5979d7b546e38e414f7e9822514be443a4800529",
+        "symbol": "wstETH",
+        "weight": "0.1666"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x6694340fc020c5e6b96567843da2df01b2ce1eb6.png",
+        "address": "0x6694340fc020c5e6b96567843da2df01b2ce1eb6",
+        "symbol": "STG",
+        "weight": "0.1666"
+      },
+      {
+        "address": "0x912ce59144191c1204e64559fe8253a0e49e6548",
+        "symbol": "ARB",
+        "weight": "0.1666"
+      },
+      {
+        "address": "0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a",
+        "symbol": "GMX",
+        "weight": "0.167"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+        "address": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+        "symbol": "USDC",
+        "weight": "0.1666"
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0xbad20c15a773bf03ab973302f61fabcea5101f0a000000000000000000000034",
+    "address": "0xbad20c15a773bf03ab973302f61fabcea5101f0a",
+    "symbol": "bb-WETH-wstETH",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1685463105,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/2518/large/weth.png?1628852295",
+        "address": "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1633565443",
+        "address": "0x6c76971f98945ae98dd7d4dfca8711ebea946ea6",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "address": "0xbad20c15a773bf03ab973302f61fabcea5101f0a",
+        "symbol": "bb-WETH-wstETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0x4683e340a8049261057d5ab1b29c8d840e75695e00020000000000000000005a",
+    "address": "0x4683e340a8049261057d5ab1b29c8d840e75695e",
+    "symbol": "B-50wstETH-50GNO",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1692879740,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1633565443",
+        "address": "0x6c76971f98945ae98dd7d4dfca8711ebea946ea6",
+        "symbol": "wstETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x9c58bacc331c9aa871afd802db6379a98e80cedb.png",
+        "address": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+        "symbol": "GNO",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0x2086f52651837600180de173b09470f54ef7491000000000000000000000004f",
+    "address": "0x2086f52651837600180de173b09470f54ef74910",
+    "symbol": "staBAL3",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1691816285,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "",
+        "address": "0x2086f52651837600180de173b09470f54ef74910",
+        "symbol": "staBAL3",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/325/large/Tether.png?1668148663",
+        "address": "0x4ecaba5870353805a9f068101a40e0f32ed605c6",
+        "symbol": "USDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png?1547042389",
+        "address": "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/14584/large/wrapped-xdai-logo.png?1641888881",
+        "address": "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
+        "symbol": "WXDAI",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0xeb30c85cc528537f5350cf5684ce6a4538e13394000200000000000000000059",
+    "address": "0xeb30c85cc528537f5350cf5684ce6a4538e13394",
+    "symbol": "B-50USD-50wstETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1692879295,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "",
+        "address": "0x2086f52651837600180de173b09470f54ef74910",
+        "symbol": "staBAL3",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1633565443",
+        "address": "0x6c76971f98945ae98dd7d4dfca8711ebea946ea6",
+        "symbol": "wstETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0x0c1b9ce6bf6c01f587c2ee98b0ef4b20c6648753000000000000000000000050",
+    "address": "0x0c1b9ce6bf6c01f587c2ee98b0ef4b20c6648753",
+    "symbol": "EURe/staBAL3",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1691816970,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x0c1b9ce6bf6c01f587c2ee98b0ef4b20c6648753",
+        "symbol": "EURe/staBAL3",
+        "weight": null
+      },
+      {
+        "logoURI": "",
+        "address": "0x2086f52651837600180de173b09470f54ef74910",
+        "symbol": "staBAL3",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/23354/large/eur.png?1643926562",
+        "address": "0xcb444e90d8198415266c6a2724b7900fb12fc56e",
+        "symbol": "EURe",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0x00df7f58e1cf932ebe5f54de5970fb2bdf0ef06d00010000000000000000005b",
+    "address": "0x00df7f58e1cf932ebe5f54de5970fb2bdf0ef06d",
+    "symbol": "B-50wstETH-25BAL-25AURA",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1692880215,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x1509706a6c66ca549ff0cb464de88231ddbe213b.png",
+        "address": "0x1509706a6c66ca549ff0cb464de88231ddbe213b",
+        "symbol": "AURA",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1633565443",
+        "address": "0x6c76971f98945ae98dd7d4dfca8711ebea946ea6",
+        "symbol": "wstETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba100000625a3754423978a60c9317c58a424e3d.png",
+        "address": "0x7ef541e2a22058048904fe5744f9c7e4c57af717",
+        "symbol": "BAL",
+        "weight": "0.25"
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0x21d4c792ea7e38e0d0819c2011a2b1cb7252bd9900020000000000000000001e",
+    "address": "0x21d4c792ea7e38e0d0819c2011a2b1cb7252bd99",
+    "symbol": "50COW-50GNO",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1679666935,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x177127622c4a00f3d409b75571e12cb3c8973d3c.png",
+        "address": "0x177127622c4a00f3d409b75571e12cb3c8973d3c",
+        "symbol": "COW",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x9c58bacc331c9aa871afd802db6379a98e80cedb.png",
+        "address": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+        "symbol": "GNO",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0xb8bb1ce9c6e5401d66fe2126db6e7387e1e24ffe00020000000000000000003d",
+    "address": "0xb8bb1ce9c6e5401d66fe2126db6e7387e1e24ffe",
+    "symbol": "50WETH-50GNO",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1687722455,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/2518/large/weth.png?1628852295",
+        "address": "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
+        "symbol": "WETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x9c58bacc331c9aa871afd802db6379a98e80cedb.png",
+        "address": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+        "symbol": "GNO",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0x5c78d05b8ecf97507d1cf70646082c54faa4da95000000000000000000000030",
+    "address": "0x5c78d05b8ecf97507d1cf70646082c54faa4da95",
+    "symbol": "bb-agEUR-EURe",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1685023780,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4b1e2c2762667331bc91648052f646d1b0d35984.png",
+        "address": "0x4b1e2c2762667331bc91648052f646d1b0d35984",
+        "symbol": "agEUR",
+        "weight": null
+      },
+      {
+        "address": "0x5c78d05b8ecf97507d1cf70646082c54faa4da95",
+        "symbol": "bb-agEUR-EURe",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/23354/large/eur.png?1643926562",
+        "address": "0xcb444e90d8198415266c6a2724b7900fb12fc56e",
+        "symbol": "EURe",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0xa99fd9950b5d5dceeaf4939e221dca8ca9b938ab000100000000000000000025",
+    "address": "0xa99fd9950b5d5dceeaf4939e221dca8ca9b938ab",
+    "symbol": "25WETH-25BAL-25GNO-25wxDAI",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1681821545,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/2518/large/weth.png?1628852295",
+        "address": "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
+        "symbol": "WETH",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba100000625a3754423978a60c9317c58a424e3d.png",
+        "address": "0x7ef541e2a22058048904fe5744f9c7e4c57af717",
+        "symbol": "BAL",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x9c58bacc331c9aa871afd802db6379a98e80cedb.png",
+        "address": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+        "symbol": "GNO",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/14584/large/wrapped-xdai-logo.png?1641888881",
+        "address": "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
+        "symbol": "WXDAI",
+        "weight": "0.25"
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0x5519e2d8a0af0944ea639c6dbad69a174de3ecf800010000000000000000003b",
+    "address": "0x5519e2d8a0af0944ea639c6dbad69a174de3ecf8",
+    "symbol": "BAL-GNO-wstETH/WETH-WXDAI",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1686824090,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xba100000625a3754423978a60c9317c58a424e3d.png",
+        "address": "0x7ef541e2a22058048904fe5744f9c7e4c57af717",
+        "symbol": "BAL",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x9c58bacc331c9aa871afd802db6379a98e80cedb.png",
+        "address": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+        "symbol": "GNO",
+        "weight": "0.25"
+      },
+      {
+        "address": "0xbad20c15a773bf03ab973302f61fabcea5101f0a",
+        "symbol": "bb-WETH-wstETH",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/14584/large/wrapped-xdai-logo.png?1641888881",
+        "address": "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
+        "symbol": "WXDAI",
+        "weight": "0.25"
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0x66888e4f35063ad8bb11506a6fde5024fb4f1db0000100000000000000000053",
+    "address": "0x66888e4f35063ad8bb11506a6fde5024fb4f1db0",
+    "symbol": "staBAL3-WETH-WBTC-BPT",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1692369290,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "",
+        "address": "0x2086f52651837600180de173b09470f54ef74910",
+        "symbol": "staBAL3",
+        "weight": "0.33"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/2518/large/weth.png?1628852295",
+        "address": "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
+        "symbol": "WETH",
+        "weight": "0.34"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1548822744",
+        "address": "0x8e5bbbb09ed1ebde8674cda39a0c169401db4252",
+        "symbol": "WBTC",
+        "weight": "0.33"
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0x274dedb9356c3e1e24bfe2bf3d4349fbdbfa0d14000200000000000000000054",
+    "address": "0x274dedb9356c3e1e24bfe2bf3d4349fbdbfa0d14",
+    "symbol": "staBAL3-GNO-BPT",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1692369505,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "",
+        "address": "0x2086f52651837600180de173b09470f54ef74910",
+        "symbol": "staBAL3",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x9c58bacc331c9aa871afd802db6379a98e80cedb.png",
+        "address": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+        "symbol": "GNO",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0x4cdabe9e07ca393943acfb9286bbbd0d0a310ff600020000000000000000005c",
+    "address": "0x4cdabe9e07ca393943acfb9286bbbd0d0a310ff6",
+    "symbol": "B-50wstETH-50COW",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1692880420,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x177127622c4a00f3d409b75571e12cb3c8973d3c.png",
+        "address": "0x177127622c4a00f3d409b75571e12cb3c8973d3c",
+        "symbol": "COW",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1633565443",
+        "address": "0x6c76971f98945ae98dd7d4dfca8711ebea946ea6",
+        "symbol": "wstETH",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0x388cae2f7d3704c937313d990298ba67d70a3709000200000000000000000026",
+    "address": "0x388cae2f7d3704c937313d990298ba67d70a3709",
+    "symbol": "50AGVE-50GNO",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1681999100,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x3a97704a1b25f08aa230ae53b352e2e72ef52843",
+        "symbol": "AGVE",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x9c58bacc331c9aa871afd802db6379a98e80cedb.png",
+        "address": "0x9c58bacc331c9aa871afd802db6379a98e80cedb",
+        "symbol": "GNO",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0xfbc3112172ba256454047d7436d1e08b3cdc5031000200000000000000000015",
+    "address": "0xfbc3112172ba256454047d7436d1e08b3cdc5031",
+    "symbol": "80MIVA-20WXDAI",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1678971395,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x63e62989d9eb2d37dfdb1f93a22f063635b07d51",
+        "symbol": "MIVA",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/14584/large/wrapped-xdai-logo.png?1641888881",
+        "address": "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
+        "symbol": "WXDAI",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "GNOSIS",
+    "id": "0x4d7adc5e362a97b5ba1b02bc0447249ac81e76ad00010000000000000000003e",
+    "address": "0x4d7adc5e362a97b5ba1b02bc0447249ac81e76ad",
+    "symbol": "SMP",
+    "type": "MANAGED",
+    "addedTimestamp": 1687793575,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x4d7adc5e362a97b5ba1b02bc0447249ac81e76ad",
+        "symbol": "SMP",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/2518/large/weth.png?1628852295",
+        "address": "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1548822744",
+        "address": "0x8e5bbbb09ed1ebde8674cda39a0c169401db4252",
+        "symbol": "WBTC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png?1547042389",
+        "address": "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83",
+        "symbol": "USDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0xcd7b2232b7435595bbc7fd7962f1f352fc2cc61a0000000000000000000000f0",
+    "address": "0xcd7b2232b7435595bbc7fd7962f1f352fc2cc61a",
+    "symbol": "bb-rf-usd",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1690208087,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://beethoven-assets.s3.eu-central-1.amazonaws.com/bb-yv-USDT.png",
+        "address": "0x20715545c15c76461861cb0d6ba96929766d05a5",
+        "symbol": "bb-rfUSDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://beethoven-assets.s3.eu-central-1.amazonaws.com/bb-yv-DAI%402x.png",
+        "address": "0xa5d4802b4ce6b745b0c9e1b4a79c093d197869c8",
+        "symbol": "bb-rfDAI",
+        "weight": null
+      },
+      {
+        "address": "0xcd7b2232b7435595bbc7fd7962f1f352fc2cc61a",
+        "symbol": "bb-rf-usd",
+        "weight": null
+      },
+      {
+        "logoURI": "https://beethoven-assets.s3.eu-central-1.amazonaws.com/bb-yv-USDC%402x.png",
+        "address": "0xf970659221bb9d01b615321b63a26e857ffc030b",
+        "symbol": "bb-rfUSDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0x8a2872fd28f42bd9f6559907235e83fbf4167f480001000000000000000000f2",
+    "address": "0x8a2872fd28f42bd9f6559907235e83fbf4167f48",
+    "symbol": "bb-rf-triple",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1690208361,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://beethoven-assets.s3.eu-central-1.amazonaws.com/bb-yv-ETH.png",
+        "address": "0x48ace81c09382bfc08ed102e7eadd37e3b049752",
+        "symbol": "bb-rfWSTETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://beethoven-assets.s3.eu-central-1.amazonaws.com/bb-yv-BTC.png",
+        "address": "0x8025586ac5fb265a23b9492e7414beccc2059ec3",
+        "symbol": "bb-rfWBTC",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://beethoven-assets.s3.eu-central-1.amazonaws.com/bb-yv-USDC%402x.png",
+        "address": "0xf970659221bb9d01b615321b63a26e857ffc030b",
+        "symbol": "bb-rfUSDC",
+        "weight": "0.25"
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0x4fd63966879300cafafbb35d157dc5229278ed2300020000000000000000002b",
+    "address": "0x4fd63966879300cafafbb35d157dc5229278ed23",
+    "symbol": "BPT-rETH-ETH",
+    "type": "METASTABLE",
+    "addedTimestamp": 1660303682,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/20764/large/reth.png?1637652366",
+        "address": "0x9bcef72be871e61ed4fbbc7630889bee758eb81d",
+        "symbol": "rETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0x7ca75bdea9dede97f8b13c6641b768650cb837820002000000000000000000d5",
+    "address": "0x7ca75bdea9dede97f8b13c6641b768650cb83782",
+    "symbol": "ECLP-wstETH-WETH",
+    "type": "GYROE",
+    "addedTimestamp": 1687519427,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1633565443",
+        "address": "0x1f32b1c2345538c0c6f582fcb022739c4a194ebb",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0x7fe29a818438ed2759e30f65c2302295711d66fc0000000000000000000000e5",
+    "address": "0x7fe29a818438ed2759e30f65c2302295711d66fc",
+    "symbol": "bb-doldol",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689772195,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x7fe29a818438ed2759e30f65c2302295711d66fc",
+        "symbol": "bb-doldol",
+        "weight": null
+      },
+      {
+        "address": "0xbef1ccaada458a570c37b11a8872988ba1e4fdb9",
+        "symbol": "bb-rfUSDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/29744/large/ERN200x200.png?1681106290",
+        "address": "0xc5b001dc33727f8f26880b184090d3e252470d45",
+        "symbol": "ERN",
+        "weight": null
+      },
+      {
+        "address": "0xdc2007d9e9a33f50630f26069faab69c25f7758c",
+        "symbol": "bb-rfUSDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0xacfe9b4782910a853b68abba60f3fd8049ffe6380000000000000000000000ff",
+    "address": "0xacfe9b4782910a853b68abba60f3fd8049ffe638",
+    "symbol": "bpt-dolausdc",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1693579309,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png",
+        "address": "0x7f5c764cbc14f9669b88837ca1490cca17c31607",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x865377367054516e17014ccded1e7d814edc9ce4.png",
+        "address": "0x8ae125e8653821e851f12a49f7765db9a9ce7384",
+        "symbol": "DOLA",
+        "weight": null
+      },
+      {
+        "address": "0xacfe9b4782910a853b68abba60f3fd8049ffe638",
+        "symbol": "bpt-dolausdc",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0x0244b0025264dc5f5c113d472d579c9c994a59ce0002000000000000000000c9",
+    "address": "0x0244b0025264dc5f5c113d472d579c9c994a59ce",
+    "symbol": "BPT-OPARA",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1681921451,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/25244/large/OP.jpeg?1651026279",
+        "address": "0x4200000000000000000000000000000000000042",
+        "symbol": "OP",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xd3594e879b358f430e20f82bea61e83562d49d48",
+        "symbol": "PSP",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0xd20f6f1d8a675cdca155cb07b5dc9042c467153f0002000000000000000000bc",
+    "address": "0xd20f6f1d8a675cdca155cb07b5dc9042c467153f",
+    "symbol": "BPT-BOATH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1680030649,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://beethoven-assets.s3.eu-central-1.amazonaws.com/OATH_Old_v3.svg",
+        "address": "0x39fde572a18448f8139b7788099f0a0740f51205",
+        "symbol": "OATH",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb200020000000000000000008b",
+    "address": "0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2",
+    "symbol": "BPT-WSTETH-WETH",
+    "type": "METASTABLE",
+    "addedTimestamp": 1673451365,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/18834/large/wstETH.png?1633565443",
+        "address": "0x1f32b1c2345538c0c6f582fcb022739c4a194ebb",
+        "symbol": "wstETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0x39965c9dab5448482cf7e002f583c812ceb53046000100000000000000000003",
+    "address": "0x39965c9dab5448482cf7e002f583c812ceb53046",
+    "symbol": "BPT-ROAD",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1654093886,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": "0.4"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/25244/large/OP.jpeg?1651026279",
+        "address": "0x4200000000000000000000000000000000000042",
+        "symbol": "OP",
+        "weight": "0.4"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png",
+        "address": "0x7f5c764cbc14f9669b88837ca1490cca17c31607",
+        "symbol": "USDC",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0x11f0b5cca01b0f0a9fe6265ad6e8ee3419c684400002000000000000000000d4",
+    "address": "0x11f0b5cca01b0f0a9fe6265ad6e8ee3419c68440",
+    "symbol": "BPT-BREV",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1686904043,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xd3594e879b358f430e20f82bea61e83562d49d48",
+        "symbol": "PSP",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0x1cc3e990b23a09fc9715aaf7ccf21c212a9cbc160001000000000000000000bd",
+    "address": "0x1cc3e990b23a09fc9715aaf7ccf21c212a9cbc16",
+    "symbol": "BPT-OG",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1680407194,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://beethoven-assets.s3.eu-central-1.amazonaws.com/OATH_Old_v3.svg",
+        "address": "0x39fde572a18448f8139b7788099f0a0740f51205",
+        "symbol": "OATH",
+        "weight": "0.35"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": "0.15"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png",
+        "address": "0x7f5c764cbc14f9669b88837ca1490cca17c31607",
+        "symbol": "USDC",
+        "weight": "0.15"
+      },
+      {
+        "address": "0xfd389dc9533717239856190f42475d3f263a270d",
+        "symbol": "GRAIN",
+        "weight": "0.35"
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0x373643b17cd80e37675c8c98ef774efe6ca0b4de00000000000000000000001c",
+    "address": "0x373643b17cd80e37675c8c98ef774efe6ca0b4de",
+    "symbol": "BPT-STABEET",
+    "type": "STABLE",
+    "addedTimestamp": 1656035393,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png",
+        "address": "0x7f5c764cbc14f9669b88837ca1490cca17c31607",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/325/large/Tether-logo.png",
+        "address": "0x94b008aa00579c1307b0ef2c499ad98a8ce58e58",
+        "symbol": "USDT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png",
+        "address": "0xda10009cbd5d07dd0cecc66161fc93d7c9000da1",
+        "symbol": "DAI",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0x0a54996ce9ceaa449cde73da6aa0368bfe3df6dc000200000000000000000017",
+    "address": "0x0a54996ce9ceaa449cde73da6aa0368bfe3df6dc",
+    "symbol": "BPT-BICO",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1655307841,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": "0.2"
+      },
+      {
+        "address": "0xd6909e9e702024eb93312b989ee46794c0fb1c9d",
+        "symbol": "BICO",
+        "weight": "0.8"
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0xd6e5824b54f64ce6f1161210bc17eebffc77e031000100000000000000000006",
+    "address": "0xd6e5824b54f64ce6f1161210bc17eebffc77e031",
+    "symbol": "BPT-LOVE",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1654097608,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/25244/large/OP.jpeg?1651026279",
+        "address": "0x4200000000000000000000000000000000000042",
+        "symbol": "OP",
+        "weight": "0.2"
+      },
+      {
+        "address": "0x97513e975a7fa9072c72c92d8000b0db90b163c5",
+        "symbol": "BEETS",
+        "weight": "0.4"
+      },
+      {
+        "address": "0xfe8b128ba8c78aabc59d4c64cee7ff28e9379921",
+        "symbol": "BAL",
+        "weight": "0.4"
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0x5028497af0c9a54ea8c6d42a054c0341b9fc6168000100000000000000000004",
+    "address": "0x5028497af0c9a54ea8c6d42a054c0341b9fc6168",
+    "symbol": "BPT-LONG",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1654094936,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": "0.333333333333333333"
+      },
+      {
+        "address": "0x68f180fcce6836688e9084f035309e29bf0a2095",
+        "symbol": "WBTC",
+        "weight": "0.333333333333333333"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png",
+        "address": "0x7f5c764cbc14f9669b88837ca1490cca17c31607",
+        "symbol": "USDC",
+        "weight": "0.333333333333333334"
+      }
+    ]
+  },
+  {
+    "chain": "OPTIMISM",
+    "id": "0xefb0d9f51efd52d7589a9083a6d0ca4de416c24900020000000000000000002c",
+    "address": "0xefb0d9f51efd52d7589a9083a6d0ca4de416c249",
+    "symbol": "BPT-IBETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1660490010,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x00a35fd824c717879bf370e70ac6868b95870dfb",
+        "symbol": "IB",
+        "weight": "0.8"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": "0.2"
+      }
+    ]
+  },
+  {
+    "id": "0xfb4c2e6e6e27b5b4a07a36360c89ede29bb3c9b6000000000000000000000026",
+    "address": "0xfb4c2e6e6e27b5b4a07a36360c89ede29bb3c9b6",
+    "symbol": "cbETH/WETH",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692241741,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22.png",
+        "address": "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22",
+        "symbol": "cbETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "address": "0xfb4c2e6e6e27b5b4a07a36360c89ede29bb3c9b6",
+        "symbol": "cbETH/WETH",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "id": "0x433f09ca08623e48bac7128b7105de678e37d988000100000000000000000047",
+    "address": "0x433f09ca08623e48bac7128b7105de678e37d988",
+    "symbol": "50GOLD/25WETH/25USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1694033265,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png?1547042389",
+        "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "symbol": "USDC",
+        "weight": "0.25"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbefd5c25a59ef2c1316c5a4944931171f30cd3e4.png",
+        "address": "0xbefd5c25a59ef2c1316c5a4944931171f30cd3e4",
+        "symbol": "GOLD",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "id": "0x0c659734f1eef9c63b7ebdf78a164cdd745586db000000000000000000000046",
+    "address": "0x0c659734f1eef9c63b7ebdf78a164cdd745586db",
+    "symbol": "USDC/USDbC/axlUSDC",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1694032789,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x0c659734f1eef9c63b7ebdf78a164cdd745586db",
+        "symbol": "USDC/USDbC/axlUSDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png?1547042389",
+        "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca.png",
+        "address": "0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca",
+        "symbol": "USDbC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/26476/large/uausdc_D_3x.png?1690776252",
+        "address": "0xeb466342c4d449bc9f53a865d5cb90586f405215",
+        "symbol": "axlUSDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "id": "0xc771c1a5905420daec317b154eb13e4198ba97d0000000000000000000000023",
+    "address": "0xc771c1a5905420daec317b154eb13e4198ba97d0",
+    "symbol": "rETH-WETH-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692107167,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c.png",
+        "address": "0xb6fe221fe9eef5aba221c348ba20a1bf5e73624c",
+        "symbol": "rETH",
+        "weight": null
+      },
+      {
+        "address": "0xc771c1a5905420daec317b154eb13e4198ba97d0",
+        "symbol": "rETH-WETH-BPT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "id": "0x17e7d59bb209a3215ccc25fffef7161498b7c10d000200000000000000000020",
+    "address": "0x17e7d59bb209a3215ccc25fffef7161498b7c10d",
+    "symbol": "1WETH-99GOLD",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1691862139,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": "0.01"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbefd5c25a59ef2c1316c5a4944931171f30cd3e4.png",
+        "address": "0xbefd5c25a59ef2c1316c5a4944931171f30cd3e4",
+        "symbol": "GOLD",
+        "weight": "0.99"
+      }
+    ]
+  },
+  {
+    "id": "0xb328b50f1f7d97ee8ea391ab5096dd7657555f49000100000000000000000048",
+    "address": "0xb328b50f1f7d97ee8ea391ab5096dd7657555f49",
+    "symbol": "GOLD/BAL/USDC",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1694033753,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x4158734d47fc9692176b5085e0f52ee0da5d47f1.png",
+        "address": "0x4158734d47fc9692176b5085e0f52ee0da5d47f1",
+        "symbol": "BAL",
+        "weight": "0.333333333"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png?1547042389",
+        "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "symbol": "USDC",
+        "weight": "0.333333333"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbefd5c25a59ef2c1316c5a4944931171f30cd3e4.png",
+        "address": "0xbefd5c25a59ef2c1316c5a4944931171f30cd3e4",
+        "symbol": "GOLD",
+        "weight": "0.333333334"
+      }
+    ]
+  },
+  {
+    "id": "0xe40cbccba664c7b1a953827c062f5070b78de86800020000000000000000001b",
+    "address": "0xe40cbccba664c7b1a953827c062f5070b78de868",
+    "symbol": "50WETH-50GOLD",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1691590801,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": "0.5"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xbefd5c25a59ef2c1316c5a4944931171f30cd3e4.png",
+        "address": "0xbefd5c25a59ef2c1316c5a4944931171f30cd3e4",
+        "symbol": "GOLD",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "id": "0x6fbfcf88db1aada31f34215b2a1df7fafb4883e900000000000000000000000c",
+    "address": "0x6fbfcf88db1aada31f34215b2a1df7fafb4883e9",
+    "symbol": "BPT-stabal3",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1691003665,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x50c5725949a6f0c72e6c4a641f24049a917db0cb",
+        "symbol": "DAI",
+        "weight": null
+      },
+      {
+        "address": "0x6fbfcf88db1aada31f34215b2a1df7fafb4883e9",
+        "symbol": "BPT-stabal3",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca.png",
+        "address": "0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca",
+        "symbol": "USDbC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "id": "0xa892be6ee527f4fb8b3b60486a53c0627cb1d27e000200000000000000000014",
+    "address": "0xa892be6ee527f4fb8b3b60486a53c0627cb1d27e",
+    "symbol": "50WETH-50LINU",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1691423711,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": "0.5"
+      },
+      {
+        "address": "0xa48c87061f4081ca8b4e2bc01711edefb0dab2fc",
+        "symbol": "LINU",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "id": "0x2db50a0e0310723ef0c2a165cb9a9f80d772ba2f00020000000000000000000d",
+    "address": "0x2db50a0e0310723ef0c2a165cb9a9f80d772ba2f",
+    "symbol": "BPT-50STABAL3-50WETH",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1691004073,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880",
+        "address": "0x4200000000000000000000000000000000000006",
+        "symbol": "WETH",
+        "weight": "0.5"
+      },
+      {
+        "address": "0x6fbfcf88db1aada31f34215b2a1df7fafb4883e9",
+        "symbol": "BPT-stabal3",
+        "weight": "0.5"
+      }
+    ]
+  },
+  {
+    "id": "0xfd2620c9cfcec7d152467633b3b0ca338d3d78cc00000000000000000000001c",
+    "address": "0xfd2620c9cfcec7d152467633b3b0ca338d3d78cc",
+    "symbol": "sAVAX-WAVAX-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692038154,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/23657/large/savax_blue.png?1644989825",
+        "address": "0x2b2c81e08f1af8835a78bb2a90ae924ace0ea4be",
+        "symbol": "sAVAX",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/avalanchec/assets/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7/logo.png",
+        "address": "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7",
+        "symbol": "WAVAX",
+        "weight": null
+      },
+      {
+        "address": "0xfd2620c9cfcec7d152467633b3b0ca338d3d78cc",
+        "symbol": "sAVAX-WAVAX-BPT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "id": "0xc13546b97b9b1b15372368dc06529d7191081f5b00000000000000000000001d",
+    "address": "0xc13546b97b9b1b15372368dc06529d7191081f5b",
+    "symbol": "ggAVAX-WAVAX-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692038316,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xa25eaf2906fa1a3a13edac9b9657108af7b703e3.png",
+        "address": "0xa25eaf2906fa1a3a13edac9b9657108af7b703e3",
+        "symbol": "ggAVAX",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/avalanchec/assets/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7/logo.png",
+        "address": "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7",
+        "symbol": "WAVAX",
+        "weight": null
+      },
+      {
+        "address": "0xc13546b97b9b1b15372368dc06529d7191081f5b",
+        "symbol": "ggAVAX-WAVAX-BPT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "id": "0xb26f0e66317846bd5fe0cbaa1d269f0efeb05c9600000000000000000000001e",
+    "address": "0xb26f0e66317846bd5fe0cbaa1d269f0efeb05c96",
+    "symbol": "USDC-USDT-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692038450,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/avalanchec/assets/0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7/logo.png",
+        "address": "0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7",
+        "symbol": "USDt",
+        "weight": null
+      },
+      {
+        "address": "0xb26f0e66317846bd5fe0cbaa1d269f0efeb05c96",
+        "symbol": "USDC-USDT-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/avalanchec/assets/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E/logo.png",
+        "address": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+        "symbol": "USDC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "id": "0x9fa6ab3d78984a69e712730a2227f20bcc8b5ad900000000000000000000001f",
+    "address": "0x9fa6ab3d78984a69e712730a2227f20bcc8b5ad9",
+    "symbol": "yyAVAX-WAVAX-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1692038616,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x9fa6ab3d78984a69e712730a2227f20bcc8b5ad9",
+        "symbol": "yyAVAX-WAVAX-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/avalanchec/assets/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7/logo.png",
+        "address": "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7",
+        "symbol": "WAVAX",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf7d9281e8e363584973f946201b82ba72c965d27.png",
+        "address": "0xf7d9281e8e363584973f946201b82ba72c965d27",
+        "symbol": "yyAVAX",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "id": "0x55bec22f8f6c69137ceaf284d9b441db1b9bfedc000200000000000000000011",
+    "address": "0x55bec22f8f6c69137ceaf284d9b441db1b9bfedc",
+    "symbol": "BPT",
+    "type": "FX",
+    "addedTimestamp": 1689325569,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/avalanchec/assets/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E/logo.png",
+        "address": "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e",
+        "symbol": "USDC",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/26045/large/euro-coin.png?1655394420",
+        "address": "0xc891eb4cbdeff6e073e859e987815ed1505c2acd",
+        "symbol": "EUROC",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "id": "0x721bd1900aeabc29009b08e44be37529f518f2c2000100000000000000000026",
+    "address": "0x721bd1900aeabc29009b08e44be37529f518f2c2",
+    "symbol": "33VCHF-33sAVAX-33VEUR",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1696338373,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x228a48df6819ccc2eca01e2192ebafffdad56c19",
+        "symbol": "VCHF",
+        "weight": "0.3333"
+      },
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/23657/large/savax_blue.png?1644989825",
+        "address": "0x2b2c81e08f1af8835a78bb2a90ae924ace0ea4be",
+        "symbol": "sAVAX",
+        "weight": "0.3334"
+      },
+      {
+        "address": "0x7678e162f38ec9ef2bfd1d0aaf9fd93355e5fa0b",
+        "symbol": "VEUR",
+        "weight": "0.3333"
+      }
+    ]
+  },
+  {
+    "id": "0xa154009870e9b6431305f19b09f9cfd7284d4e7a000000000000000000000013",
+    "address": "0xa154009870e9b6431305f19b09f9cfd7284d4e7a",
+    "symbol": "sAVAX-bb-a-WAVAX-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689792870,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/23657/large/savax_blue.png?1644989825",
+        "address": "0x2b2c81e08f1af8835a78bb2a90ae924ace0ea4be",
+        "symbol": "sAVAX",
+        "weight": null
+      },
+      {
+        "address": "0x7275c131b1f67e8b53b4691f92b0e35a4c1c6e22",
+        "symbol": "bb-a-WAVAX",
+        "weight": null
+      },
+      {
+        "address": "0xa154009870e9b6431305f19b09f9cfd7284d4e7a",
+        "symbol": "sAVAX-bb-a-WAVAX-BPT",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "id": "0x7275c131b1f67e8b53b4691f92b0e35a4c1c6e22000000000000000000000010",
+    "address": "0x7275c131b1f67e8b53b4691f92b0e35a4c1c6e22",
+    "symbol": "bb-a-WAVAX",
+    "type": "ERC4626LINEAR",
+    "addedTimestamp": 1689189319,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x7275c131b1f67e8b53b4691f92b0e35a4c1c6e22",
+        "symbol": "bb-a-WAVAX",
+        "weight": null
+      },
+      {
+        "address": "0xa291ae608d8854cdbf9838e28e9badcf10181669",
+        "symbol": "stataAvaWAVAX",
+        "weight": null
+      },
+      {
+        "logoURI": "https://assets-cdn.trustwallet.com/blockchains/avalanchec/assets/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7/logo.png",
+        "address": "0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7",
+        "symbol": "WAVAX",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "id": "0xece571847897fd61e764d455dc15cf1cd9de8d6f000000000000000000000014",
+    "address": "0xece571847897fd61e764d455dc15cf1cd9de8d6f",
+    "symbol": "yyAVAX-bb-a-WAVAX-BPT",
+    "type": "COMPOSABLESTABLE",
+    "addedTimestamp": 1689850089,
+    "gauge": {},
+    "tokens": [
+      {
+        "address": "0x7275c131b1f67e8b53b4691f92b0e35a4c1c6e22",
+        "symbol": "bb-a-WAVAX",
+        "weight": null
+      },
+      {
+        "address": "0xece571847897fd61e764d455dc15cf1cd9de8d6f",
+        "symbol": "yyAVAX-bb-a-WAVAX-BPT",
+        "weight": null
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0xf7d9281e8e363584973f946201b82ba72c965d27.png",
+        "address": "0xf7d9281e8e363584973f946201b82ba72c965d27",
+        "symbol": "yyAVAX",
+        "weight": null
+      }
+    ]
+  },
+  {
+    "id": "0x3396cca90c9335565ecdbae3a260dafb13a7959e000200000000000000000018",
+    "address": "0x3396cca90c9335565ecdbae3a260dafb13a7959e",
+    "symbol": "80BETS/20sAVAX",
+    "type": "WEIGHTED",
+    "addedTimestamp": 1690622794,
+    "gauge": {},
+    "tokens": [
+      {
+        "logoURI": "https://assets.coingecko.com/coins/images/23657/large/savax_blue.png?1644989825",
+        "address": "0x2b2c81e08f1af8835a78bb2a90ae924ace0ea4be",
+        "symbol": "sAVAX",
+        "weight": "0.2"
+      },
+      {
+        "logoURI": "https://raw.githubusercontent.com/balancer/tokenlists/main/src/assets/images/tokens/0x94025780a1ab58868d9b2dbbb775f44b32e8e6e5.png",
+        "address": "0x94025780a1ab58868d9b2dbbb775f44b32e8e6e5",
+        "symbol": "BETS",
+        "weight": "0.8"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Before it wouldn't average value if it was a nested Obj, ex:
``` 
[<day>]: [
  {
    "poolId": "0x1ee442b5326009bb18f2f472d3e0061513d1a0ff000200000000000000000464",
        "apr": {
          "total": 15.743566851554217,
          "breakdown": {
            "veBAL": 9.326595933579101
          }
        }
  }],
[<day 2>]: [
  {
    "poolId": "0x1ee442b5326009bb18f2f472d3e0061513d1a0ff000200000000000000000464",
        "apr": {
          "total": 15.743566851554217,
          "breakdown": {
            "veBAL": 9.326595933579101
          }
        }
  },
]
```

It wouldn't iterate over APR's values, so would end up adding