### PR TITLE
[APR] Historical Chart UI improvements

### DIFF
--- a/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalCharts/HistoricalChart.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalCharts/HistoricalChart.tsx
@@ -38,10 +38,10 @@ export default function HistoricalChartWrapper({
   const charts = ["APR", "Weekly Swap Fees", "TVL", "Volume"];
   const [selectedTabs, setselectedTabs] = useState([0]);
 
-  const aprChartData = formatAPRChartData(apiResult, "y2");
+  const feeChartData = formatSwapFeeChartData(apiResult, "y2");
   const tvlChartData = formatTvlChartData(apiResult, "y3");
   const volumeChartData = formatVolumeChartData(apiResult, "y4");
-  const feeChartData = formatSwapFeeChartData(apiResult, "y5");
+  const aprChartData = formatAPRChartData(apiResult, "y5");
   const activeCharts = getActiveData(
     selectedTabs,
     aprChartData,
@@ -101,8 +101,9 @@ export default function HistoricalChartWrapper({
             linecolor: blueDark.blue6,
             mirror: true,
             fixedrange: true,
-            title: "APR %",
+            title: "Swap Fee",
             overlaying: "y",
+            side: "right",
             anchor: "free",
             // @ts-ignore: 2322
             autoshift: true,
@@ -136,9 +137,8 @@ export default function HistoricalChartWrapper({
             linecolor: blueDark.blue6,
             mirror: true,
             fixedrange: true,
-            title: "Swap Fee",
+            title: "APR %",
             overlaying: "y",
-            side: "right",
             anchor: "free",
             // @ts-ignore: 2322
             autoshift: true,

--- a/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalCharts/HistoricalData/formatSwapFeeChartData.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalCharts/HistoricalData/formatSwapFeeChartData.tsx
@@ -25,6 +25,7 @@ export default function HistoricalSwapFeeChartData(
     y: trimmedCollectedSwapFeeData.y,
     marker: {
       color: normalBarColor,
+      opacity: 1,
     },
     line: { shape: "spline" } as const,
     type: "bar" as PlotType,

--- a/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalCharts/HistoricalData/formatTvlChartData.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalCharts/HistoricalData/formatTvlChartData.tsx
@@ -1,4 +1,4 @@
-import { yellowDarkA } from "@radix-ui/colors";
+import { amberDark } from "@radix-ui/colors";
 import { PlotType } from "plotly.js";
 
 import { PoolStatsResults } from "#/app/apr/api/route";
@@ -21,7 +21,11 @@ export default function formatTvlChartData(
     hovertemplate: "%{y:$,.0f}",
     x: trimmedTotalAprData.x,
     y: trimmedTotalAprData.y,
-    line: { shape: "spline", color: yellowDarkA.yellowA9 } as const,
+    marker: {
+      color: amberDark.amber9,
+      opacity: 0.8,
+    },
+    line: { shape: "spline" } as const,
     type: "bar" as PlotType,
     // @ts-ignore: 2322
     offsetgroup: 2,

--- a/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalCharts/HistoricalData/formatVolumeChartData.tsx
+++ b/apps/balancer-tools/src/app/apr/pool/(components)/HistoricalCharts/HistoricalData/formatVolumeChartData.tsx
@@ -1,4 +1,4 @@
-import { redDarkA } from "@radix-ui/colors";
+import { blueDarkA } from "@radix-ui/colors";
 import { PlotType } from "plotly.js";
 
 import { PoolStatsResults } from "#/app/apr/api/route";
@@ -23,7 +23,11 @@ export default function formatVolumeChartData(
     hovertemplate: HOVERTEMPLATE,
     x: trimmedTotalAprData.x,
     y: trimmedTotalAprData.y,
-    line: { shape: "spline", color: redDarkA.redA9 } as const,
+    marker: {
+      color: blueDarkA.blueA9,
+      opacity: 0.8,
+    },
+    line: { shape: "spline" } as const,
     type: "bar" as PlotType,
     // @ts-ignore: 2322
     offsetgroup: 3,


### PR DESCRIPTION
This PR:
- changes bar opacity
- moves APR traces to be always on the front

https://www.loom.com/share/39574ea16bc2460083ae9a6f9b7ab6e6?sid=a330bead-d596-40b9-a4d8-e21b816708ac